### PR TITLE
Fix worktree workflow bugs

### DIFF
--- a/server/src/routes/fs.rs
+++ b/server/src/routes/fs.rs
@@ -292,12 +292,44 @@ pub async fn open_external(Json(request): Json<OpenExternalRequest>) -> impl Int
     // Execute the appropriate command based on target
     let result = match request.target.as_str() {
         "vscode" => {
-            // Use "code" command for VS Code
-            std::process::Command::new("code").arg(&path).spawn()
+            // Try "code" command first, fall back to macOS open command
+            let code_result = std::process::Command::new("code").arg(&path).spawn();
+            if code_result.is_err() {
+                // Fallback for macOS: use open -a "Visual Studio Code"
+                #[cfg(target_os = "macos")]
+                {
+                    std::process::Command::new("open")
+                        .args(["-a", "Visual Studio Code"])
+                        .arg(&path)
+                        .spawn()
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    code_result
+                }
+            } else {
+                code_result
+            }
         }
         "cursor" => {
-            // Use "cursor" command for Cursor
-            std::process::Command::new("cursor").arg(&path).spawn()
+            // Try "cursor" command first, fall back to macOS open command
+            let cursor_result = std::process::Command::new("cursor").arg(&path).spawn();
+            if cursor_result.is_err() {
+                // Fallback for macOS: use open -a "Cursor"
+                #[cfg(target_os = "macos")]
+                {
+                    std::process::Command::new("open")
+                        .args(["-a", "Cursor"])
+                        .arg(&path)
+                        .spawn()
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    cursor_result
+                }
+            } else {
+                cursor_result
+            }
         }
         "finder" => {
             // Use the `open` crate for cross-platform support


### PR DESCRIPTION
Closes beads-kanban-ui-9eh

Three bugs found during testing:

1. **Open in IDE fails** - Error: 'No such file or directory'
   - File: server/src/routes/worktree.rs (openExternal handler)
   - Fix: Use 'open -a "Visual Studio Code"' on macOS instead of 'code' command

2. **Merge PR shows error even on success** - 'failed to delete local branch used by worktree'
   - File: server/src/routes/worktree.rs (mergePR handler)  
   - Fix: After merge succeeds, delete worktree first, then delete branch. Or just skip branch deletion since cleanup handles it.

3. **Cleanup doesn't close bead** - Returns success but bead stays in current column
   - File: server/src/routes/worktree.rs (deleteWorktree handler)
   - Fix: After worktree removal, run 'bd close {bead_id}' to mark bead as closed