### PR TITLE
Fix CI: create dummy out folder for RustEmbed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
+      # Create dummy out/ folder for RustEmbed (requires folder to exist at compile time)
+      - name: Create dummy out folder
+        run: mkdir -p out && echo "<html></html>" > out/index.html
       - run: cargo check --manifest-path server/Cargo.toml
       - run: cargo test --manifest-path server/Cargo.toml
       - run: cargo clippy --manifest-path server/Cargo.toml -- -D warnings


### PR DESCRIPTION
The Rust backend uses RustEmbed which requires the out/ folder to exist at compile time. In CI, the frontend hasn't been built yet, so we create a minimal dummy folder to allow cargo check/test/clippy to run.