### PR TITLE
Fix rebase-siblings push to use explicit branch name

### DIFF
--- a/server/src/routes/worktree.rs
+++ b/server/src/routes/worktree.rs
@@ -1398,9 +1398,11 @@ async fn rebase_single_worktree(worktree_path: &str, bead_id: &str) -> RebaseSib
 
     match rebase_output {
         Ok(output) if output.status.success() => {
-            // Rebase succeeded, force push
+            // Rebase succeeded, force push with explicit branch name
+            // (branch may not have upstream tracking configured)
+            let branch_name = format!("bd-{}", bead_id);
             let push_output = Command::new("git")
-                .args(["push", "--force-with-lease"])
+                .args(["push", "origin", &branch_name, "--force-with-lease"])
                 .current_dir(worktree_path)
                 .output()
                 .await;


### PR DESCRIPTION
Closes beads-kanban-ui-3wz

The push after rebase fails when branch has no upstream tracking. Change 'git push --force-with-lease' to 'git push origin bd-{bead_id} --force-with-lease'.