### PR TITLE
Fix epic child PR status display on kanban cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ SPEC.md
 test-*.md
 test-*.txt
 .verification_logs/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
Closes beads-kanban-ui-e2b

1. EpicCard doesn't pass childPRStatuses to SubtaskList - PR icons only show in bead-detail sidebar
2. Add auto-refresh every 30 seconds with persistence
3. Add hover tooltip explaining PR status (open/merged, checks pass/fail/pending)