### PR TITLE
Fix legacy branch status showing 'Merged' incorrectly

### DIFF
--- a/src/components/bead-card.tsx
+++ b/src/components/bead-card.tsx
@@ -357,7 +357,7 @@ function getLegacyBranchStatusLabel(status: BranchStatus): string {
   } else if (ahead > 0 && behind === 0) {
     return "Ready to merge";
   } else if (ahead === 0 && behind > 0) {
-    return "Merged";
+    return "Behind";
   }
   return "Synced";
 }


### PR DESCRIPTION
Closes beads-kanban-ui-hwv

When a branch has ahead=0, behind>0, the UI shows 'Merged' which is incorrect.

Root cause: getLegacyBranchStatusLabel() in bead-card.tsx:335-346
Returns 'Merged' when ahead===0 && behind>0, but this actually means 'Behind main' not merged.

Fix: Change the label to 'Behind' or 'Needs update' instead of 'Merged'.
'Merged' should only be shown when PR state is actually merged.