### PR TITLE
Fix epic auto-inreview when all children closed

### DIFF
--- a/server/src/routes/beads.rs
+++ b/server/src/routes/beads.rs
@@ -434,9 +434,8 @@ fn compute_epic_status_from_children(child_statuses: &[&str]) -> Option<&'static
     let all_inreview_or_closed = child_statuses
         .iter()
         .all(|s| *s == "inreview" || *s == "closed");
-    let has_inreview = child_statuses.contains(&"inreview");
 
-    if all_inreview_or_closed && has_inreview {
+    if all_inreview_or_closed {
         return Some("inreview");
     }
 
@@ -678,9 +677,9 @@ mod tests {
 
     #[test]
     fn test_compute_epic_status_all_closed() {
-        // All children closed -> No change (don't auto-close epic)
+        // All children closed -> Epic should be inreview (ready for final review)
         let statuses = vec!["closed", "closed"];
-        assert_eq!(compute_epic_status_from_children(&statuses), None);
+        assert_eq!(compute_epic_status_from_children(&statuses), Some("inreview"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixed bug where epic didn't auto-move to inreview when all children were closed
- Removed unnecessary `has_inreview` requirement from `compute_epic_status_from_children()`
- Updated corresponding test to expect "inreview" when all children are closed

## Test plan
- [x] `cargo test` passes
- [ ] Manual test: close all children of an epic, verify epic moves to inreview

🤖 Generated with [Claude Code](https://claude.com/claude-code)