### PR TITLE
Fix Agentation not rendering in Next.js

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { Space_Grotesk, Plus_Jakarta_Sans } from 'next/font/google';
 import { Toaster } from '@/components/ui/toaster';
-import { Agentation } from 'agentation';
+import { DevTools } from '@/components/dev-tools';
 import './globals.css';
 
 const spaceGrotesk = Space_Grotesk({
@@ -31,7 +31,7 @@ export default function RootLayout({
       <body className="flex min-h-screen flex-col bg-background antialiased">
         <div className="flex-1">{children}</div>
         <Toaster />
-        {process.env.NODE_ENV === 'development' && <Agentation />}
+        <DevTools />
       </body>
     </html>
   );

--- a/src/components/dev-tools.tsx
+++ b/src/components/dev-tools.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const Agentation = dynamic(
+  () => import("agentation").then((mod) => mod.Agentation),
+  { ssr: false }
+);
+
+export function DevTools() {
+  if (process.env.NODE_ENV !== "development") {
+    return null;
+  }
+  return <Agentation />;
+}


### PR DESCRIPTION
## Summary
- Created DevTools client wrapper component with dynamic import
- Fixes Agentation not rendering due to Server Component context
- Uses `ssr: false` to ensure client-only rendering

## Test plan
- [ ] Run dev server
- [ ] Verify Agentation toolbar appears in bottom-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)