### PR TITLE
Skip PR status fetch for closed beads

### DIFF
--- a/src/components/bead-detail.tsx
+++ b/src/components/bead-detail.tsx
@@ -293,9 +293,9 @@ export function BeadDetail({
 
     const statusMap = new Map<string, { state: "open" | "merged" | "closed"; checks: { status: "success" | "failure" | "pending" } }>();
 
-    // Fetch PR status for all children in parallel
+    // Fetch PR status for all children in parallel (skip closed - no PR needed)
     const results = await Promise.all(
-      childTasks.map(async (child) => {
+      childTasks.filter(c => c.status !== 'closed').map(async (child) => {
         try {
           const prStatus = await api.git.prStatus(projectPath, child.id);
           if (prStatus.pr) {

--- a/src/components/epic-card.tsx
+++ b/src/components/epic-card.tsx
@@ -114,9 +114,9 @@ export function EpicCard({
 
     const statusMap = new Map<string, ChildPRStatus>();
 
-    // Fetch PR status for all children in parallel
+    // Fetch PR status for all children in parallel (skip closed - no PR needed)
     const results = await Promise.all(
-      children.map(async (child) => {
+      children.filter(c => c.status !== 'closed').map(async (child) => {
         try {
           const prStatus = await api.git.prStatus(projectPath, child.id);
           if (prStatus.pr) {


### PR DESCRIPTION
## Summary
- Filter out closed children before fetching PR status
- Applies to both epic-card.tsx and bead-detail.tsx
- Eliminates dozens of unnecessary API calls

## Test plan
- [ ] Open network tab, verify no pr-status calls for closed beads
- [ ] Epic cards still show correct PR status for open/inreview children

🤖 Generated with [Claude Code](https://claude.com/claude-code)