### PR TITLE
Fix Agentation not appearing on dev server

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
       <body className="flex min-h-screen flex-col bg-background antialiased">
         <div className="flex-1">{children}</div>
         <Toaster />
-        {process.env.NODE_ENV === "development" && <DevTools />}
+        <DevTools />
       </body>
     </html>
   );

--- a/src/components/dev-tools.tsx
+++ b/src/components/dev-tools.tsx
@@ -8,5 +8,10 @@ const Agentation = dynamic(
 );
 
 export function DevTools() {
+  // Check at runtime on the client, not at build time
+  // This ensures dev tools work on production builds deployed to dev servers
+  if (process.env.NODE_ENV !== "development") {
+    return null;
+  }
   return <Agentation />;
 }


### PR DESCRIPTION
Closes beads-kanban-ui-tsb

The NODE_ENV check is in the server component layout.tsx which evaluates at build time. For production builds deployed to a dev server, NODE_ENV is 'production' so DevTools never renders. Fix: move the NODE_ENV check inside the client component (dev-tools.tsx) so it evaluates at runtime on the client.