### PR TITLE
Skip worktree/branch status polling for closed beads

### DIFF
--- a/src/app/project/kanban-board.tsx
+++ b/src/app/project/kanban-board.tsx
@@ -125,7 +125,8 @@ export default function KanbanBoard() {
 
   // @deprecated: Branch statuses are deprecated. TODO: migrate to useWorktreeStatuses
   // Fetch branch statuses for all beads (legacy - for backward compatibility)
-  const beadIds = useMemo(() => beads.map((b) => b.id), [beads]);
+  // Filter out closed beads to avoid unnecessary polling for finalized tasks
+  const beadIds = useMemo(() => beads.filter(b => b.status !== 'closed').map(b => b.id), [beads]);
   const { statuses: branchStatuses } = useBranchStatuses(
     project?.path ?? "",
     beadIds


### PR DESCRIPTION
Closes beads-kanban-ui-zrv

beadIds includes ALL beads including closed ones, causing unnecessary polling. Fix: filter out closed beads before passing to useBranchStatuses and useWorktreeStatuses hooks in kanban-board.tsx line 128.