### PR TITLE
Improve DevTools runtime detection

### DIFF
--- a/src/components/dev-tools.tsx
+++ b/src/components/dev-tools.tsx
@@ -7,10 +7,26 @@ const Agentation = dynamic(
   { ssr: false }
 );
 
+function isRuntimeDev(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const nextData = (window as Window & { __NEXT_DATA__?: { dev?: boolean } })
+    .__NEXT_DATA__;
+  if (typeof nextData?.dev === "boolean") {
+    return nextData.dev;
+  }
+
+  const host = window.location.hostname;
+  return host === "localhost" || host === "127.0.0.1";
+}
+
 export function DevTools() {
-  // Check at runtime on the client, not at build time
-  // This ensures dev tools work on production builds deployed to dev servers
-  if (process.env.NODE_ENV !== "development") {
+  const explicitlyEnabled = process.env.NEXT_PUBLIC_AGENTATION === "1";
+  const isDev = process.env.NODE_ENV === "development" || isRuntimeDev();
+
+  if (!explicitlyEnabled && !isDev) {
     return null;
   }
   return <Agentation />;


### PR DESCRIPTION
Closes beads-kanban-ui-38d

Replace simple NODE_ENV check with runtime detection that checks __NEXT_DATA__.dev and localhost/127.0.0.1. Also add NEXT_PUBLIC_AGENTATION=1 env var override.