### PR TITLE
Remove non-functional Create task button

### DIFF
--- a/src/components/kanban-column.tsx
+++ b/src/components/kanban-column.tsx
@@ -2,7 +2,6 @@
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { BeadCard } from "@/components/bead-card";
 import { EpicCard } from "@/components/epic-card";
 import { cn } from "@/lib/utils";
@@ -171,10 +170,7 @@ export function KanbanColumn({
           {beads.length === 0 && (
             <div className="flex flex-col items-center justify-center py-8 border-2 border-dashed border-zinc-700/50 rounded-lg">
               <PackageOpen className="size-8 text-zinc-500 mb-2" aria-hidden="true" />
-              <span className="text-zinc-500 text-sm mb-3">No beads</span>
-              <Button variant="ghost" size="sm">
-                Create task
-              </Button>
+              <span className="text-zinc-500 text-sm">No beads</span>
             </div>
           )}
         </div>


### PR DESCRIPTION
Closes beads-kanban-ui-4za

Remove the Create task button from kanban-column.tsx empty state (lines 175-177). The button has no functionality yet.