### PR TITLE
Create agentform PR reviewer spec with Anthropic

### DIFF
--- a/agentform/pr-reviewer/00-project.af
+++ b/agentform/pr-reviewer/00-project.af
@@ -1,0 +1,4 @@
+agentform {
+  version = "0.1"
+  project = "beads-kanban-pr-reviewer"
+}

--- a/agentform/pr-reviewer/01-variables.af
+++ b/agentform/pr-reviewer/01-variables.af
@@ -1,0 +1,11 @@
+variable "anthropic_api_key" {
+  type        = string
+  description = "Anthropic API key for Claude model access"
+  sensitive   = true
+}
+
+variable "github_personal_access_token" {
+  type        = string
+  description = "GitHub Personal Access Token with repo and pull_request scopes"
+  sensitive   = true
+}

--- a/agentform/pr-reviewer/02-providers.af
+++ b/agentform/pr-reviewer/02-providers.af
@@ -1,0 +1,13 @@
+provider "llm.anthropic" "default" {
+  api_key = var.anthropic_api_key
+}
+
+model "claude_sonnet" {
+  provider = provider.llm.anthropic.default
+  id       = "claude-sonnet-4-20250514"
+}
+
+model "claude_haiku" {
+  provider = provider.llm.anthropic.default
+  id       = "claude-haiku-4-20250514"
+}

--- a/agentform/pr-reviewer/03-servers.af
+++ b/agentform/pr-reviewer/03-servers.af
@@ -1,0 +1,8 @@
+server "github" {
+  command = "npx"
+  args    = ["-y", "@anthropic/mcp-server-github"]
+
+  env = {
+    GITHUB_PERSONAL_ACCESS_TOKEN = var.github_personal_access_token
+  }
+}

--- a/agentform/pr-reviewer/04-capabilities.af
+++ b/agentform/pr-reviewer/04-capabilities.af
@@ -1,0 +1,20 @@
+capability "get_pr" {
+  server      = server.github
+  description = "Fetch pull request metadata including title, description, author, and status"
+}
+
+capability "list_pr_files" {
+  server      = server.github
+  description = "List all files changed in a pull request with their status (added, modified, deleted)"
+}
+
+capability "get_file_contents" {
+  server      = server.github
+  description = "Retrieve the contents of a specific file at a given ref"
+}
+
+capability "create_review" {
+  server            = server.github
+  description       = "Submit a review comment on a pull request"
+  requires_approval = true
+}

--- a/agentform/pr-reviewer/05-policies.af
+++ b/agentform/pr-reviewer/05-policies.af
@@ -1,0 +1,15 @@
+policy "review_policy" {
+  description = "Policy for thorough PR review operations"
+
+  max_cost_usd_per_run   = 0.50
+  max_capability_calls   = 15
+  timeout_seconds        = 300
+}
+
+policy "triage_policy" {
+  description = "Policy for quick PR classification operations"
+
+  max_cost_usd_per_run   = 0.05
+  max_capability_calls   = 3
+  timeout_seconds        = 30
+}

--- a/agentform/pr-reviewer/06-agents.af
+++ b/agentform/pr-reviewer/06-agents.af
@@ -1,0 +1,102 @@
+agent "reviewer" {
+  model  = model.claude_sonnet
+  policy = policy.review_policy
+
+  capabilities = [
+    capability.get_pr,
+    capability.list_pr_files,
+    capability.get_file_contents,
+    capability.create_review,
+  ]
+
+  instructions = <<-EOT
+    You are a senior code reviewer for a Next.js 14+ application using the App Router.
+
+    Tech stack:
+    - Next.js 14+ with App Router and Server Components
+    - React 18+ with TypeScript (strict mode)
+    - Tailwind CSS for styling
+    - shadcn/ui and Radix UI for component primitives
+    - Rust backend (server/ directory)
+
+    Review criteria (in priority order):
+
+    1. TypeScript Correctness
+       - Proper type annotations, no unsafe 'any' usage
+       - Correct use of generics and type narrowing
+       - Interface/type consistency across boundaries
+
+    2. React Best Practices
+       - Proper hooks usage (dependency arrays, rules of hooks)
+       - Avoid unnecessary re-renders (useMemo, useCallback when appropriate)
+       - Server Components by default, Client Components only when needed
+       - Proper Suspense boundaries for streaming
+
+    3. Accessibility (WCAG AA)
+       - Semantic HTML elements
+       - ARIA labels on interactive elements
+       - Keyboard navigation support
+       - Color contrast compliance
+
+    4. Performance
+       - No N+1 data fetching patterns
+       - Proper use of React.memo for expensive components
+       - Image optimization with next/image
+       - Bundle size awareness
+
+    5. Security
+       - No hardcoded secrets or credentials
+       - Proper input sanitization
+       - XSS prevention
+       - CSRF protection where applicable
+
+    6. Code Style
+       - Consistent naming conventions
+       - Clear component structure
+       - Appropriate file organization
+       - Meaningful variable and function names
+
+    Provide actionable feedback with specific line references.
+    Categorize issues as: CRITICAL, WARNING, or SUGGESTION.
+    Always explain WHY something is an issue, not just WHAT.
+  EOT
+}
+
+agent "classifier" {
+  model  = model.claude_haiku
+  policy = policy.triage_policy
+
+  capabilities = [
+    capability.get_pr,
+    capability.list_pr_files,
+  ]
+
+  instructions = <<-EOT
+    You are a PR complexity classifier. Analyze the pull request and classify it.
+
+    Classification levels:
+
+    TRIVIAL - Auto-approvable changes:
+    - Documentation-only changes (README, comments, JSDocs)
+    - Dependency version bumps (minor/patch)
+    - Formatting/whitespace changes
+    - Typo fixes
+
+    SIMPLE - Quick review needed:
+    - Single-file changes under 50 lines
+    - Test additions without logic changes
+    - Configuration changes
+    - Style-only changes (CSS/Tailwind)
+
+    COMPLEX - Full review required:
+    - Multi-file changes
+    - New features or components
+    - API changes
+    - Database schema changes
+    - Security-related changes
+    - Changes over 200 lines total
+
+    Output ONLY one of: TRIVIAL, SIMPLE, or COMPLEX
+    followed by a brief one-line justification.
+  EOT
+}

--- a/agentform/pr-reviewer/07-workflows.af
+++ b/agentform/pr-reviewer/07-workflows.af
@@ -1,0 +1,173 @@
+workflow "review_pr" {
+  description = "Automated PR review workflow with human-in-the-loop approval"
+
+  input {
+    owner       = string
+    repo        = string
+    pull_number = number
+  }
+
+  step "fetch_pr" {
+    agent = agent.classifier
+
+    action {
+      capability = capability.get_pr
+      params = {
+        owner       = input.owner
+        repo        = input.repo
+        pull_number = input.pull_number
+      }
+    }
+
+    output {
+      pr_data = result
+    }
+  }
+
+  step "fetch_files" {
+    agent    = agent.classifier
+    depends  = [step.fetch_pr]
+
+    action {
+      capability = capability.list_pr_files
+      params = {
+        owner       = input.owner
+        repo        = input.repo
+        pull_number = input.pull_number
+      }
+    }
+
+    output {
+      files = result
+    }
+  }
+
+  step "classify" {
+    agent   = agent.classifier
+    depends = [step.fetch_pr, step.fetch_files]
+
+    prompt = <<-EOT
+      Classify this PR:
+
+      Title: ${step.fetch_pr.pr_data.title}
+      Description: ${step.fetch_pr.pr_data.body}
+
+      Files changed: ${length(step.fetch_files.files)}
+      ${join("\n", [for f in step.fetch_files.files : "- ${f.filename} (${f.status}, +${f.additions}/-${f.deletions})"])}
+
+      Output: TRIVIAL, SIMPLE, or COMPLEX with justification.
+    EOT
+
+    output {
+      complexity = extract_first_word(result)
+    }
+  }
+
+  step "route_by_complexity" {
+    type    = "router"
+    depends = [step.classify]
+
+    routes = {
+      trivial = step.classify.complexity == "TRIVIAL"
+      review  = step.classify.complexity != "TRIVIAL"
+    }
+  }
+
+  step "auto_approve" {
+    agent   = agent.classifier
+    depends = [step.route_by_complexity]
+    condition = step.route_by_complexity.route == "trivial"
+
+    action {
+      capability = capability.create_review
+      params = {
+        owner       = input.owner
+        repo        = input.repo
+        pull_number = input.pull_number
+        event       = "APPROVE"
+        body        = "Auto-approved: ${step.classify.complexity} change. ${step.classify.result}"
+      }
+    }
+
+    terminal = true
+  }
+
+  step "analyze" {
+    agent   = agent.reviewer
+    depends = [step.route_by_complexity]
+    condition = step.route_by_complexity.route == "review"
+
+    prompt = <<-EOT
+      Review this ${step.classify.complexity} PR:
+
+      Title: ${step.fetch_pr.pr_data.title}
+      Description: ${step.fetch_pr.pr_data.body}
+      Author: ${step.fetch_pr.pr_data.user.login}
+
+      Files to review:
+      ${join("\n", [for f in step.fetch_files.files : "- ${f.filename}"])}
+
+      For each file with substantive changes, fetch its contents and review according to your criteria.
+
+      Provide a structured review with:
+      1. Summary (1-2 sentences)
+      2. Issues found (categorized as CRITICAL/WARNING/SUGGESTION)
+      3. Recommendation: APPROVE, REQUEST_CHANGES, or COMMENT
+    EOT
+
+    output {
+      review_body    = result
+      recommendation = extract_recommendation(result)
+    }
+  }
+
+  step "approval" {
+    type    = "human"
+    depends = [step.analyze]
+
+    prompt = <<-EOT
+      PR Review Ready for Submission
+
+      Repository: ${input.owner}/${input.repo}
+      PR #${input.pull_number}: ${step.fetch_pr.pr_data.title}
+
+      Recommended action: ${step.analyze.recommendation}
+
+      Review content:
+      ${step.analyze.review_body}
+
+      Do you approve submitting this review?
+    EOT
+
+    on_approve = step.submit_review
+    on_reject  = step.end_rejected
+  }
+
+  step "submit_review" {
+    agent   = agent.reviewer
+    depends = [step.approval]
+
+    action {
+      capability = capability.create_review
+      params = {
+        owner       = input.owner
+        repo        = input.repo
+        pull_number = input.pull_number
+        event       = step.analyze.recommendation
+        body        = step.analyze.review_body
+      }
+    }
+
+    terminal = true
+  }
+
+  step "end_rejected" {
+    type     = "terminal"
+    depends  = [step.approval]
+
+    output {
+      status  = "rejected"
+      message = "Review submission was rejected by human reviewer"
+    }
+  }
+}

--- a/agentform/pr-reviewer/README.md
+++ b/agentform/pr-reviewer/README.md
@@ -1,0 +1,176 @@
+# PR Reviewer - Agentform Configuration
+
+Automated PR review system using Claude (Anthropic) with human-in-the-loop approval.
+
+## Overview
+
+This agentform configuration provides intelligent PR reviews tailored for Next.js/React/TypeScript projects. It uses:
+
+- **Claude Sonnet** for thorough code review
+- **Claude Haiku** for quick PR classification
+- **MCP GitHub server** for GitHub API access
+
+## Setup
+
+### 1. Install agentform
+
+```bash
+# Install agentform CLI
+npm install -g agentform
+```
+
+### 2. Set Environment Variables
+
+Create a `.env` file or export these variables:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+export GITHUB_PERSONAL_ACCESS_TOKEN="ghp_..."
+```
+
+The GitHub token needs these scopes:
+- `repo` - Full control of private repositories
+- `pull_request` - Read/write access to pull requests
+
+### 3. Create Input File
+
+```bash
+cp input.example.yaml input.yaml
+# Edit input.yaml with your PR details
+```
+
+## Usage
+
+### Run a PR Review
+
+```bash
+# Review a specific PR
+agentform run review_pr --input input.yaml
+
+# Or pass inputs directly
+agentform run review_pr \
+  --var owner=your-org \
+  --var repo=beads-kanban-ui \
+  --var pull_number=42
+```
+
+### Dry Run (No Submissions)
+
+```bash
+agentform run review_pr --input input.yaml --dry-run
+```
+
+## Workflow
+
+```
+                    +------------+
+                    | fetch_pr   |
+                    +-----+------+
+                          |
+                    +-----v------+
+                    | fetch_files|
+                    +-----+------+
+                          |
+                    +-----v------+
+                    |  classify  |
+                    +-----+------+
+                          |
+              +-----------+-----------+
+              |                       |
+        TRIVIAL                 SIMPLE/COMPLEX
+              |                       |
+      +-------v-------+       +-------v-------+
+      | auto_approve  |       |   analyze     |
+      +-------+-------+       +-------+-------+
+              |                       |
+            [END]             +-------v-------+
+                              |   approval    |
+                              | (human gate)  |
+                              +-------+-------+
+                                      |
+                        +-------------+-------------+
+                        |                           |
+                   APPROVED                    REJECTED
+                        |                           |
+                +-------v-------+           +-------v-------+
+                | submit_review |           | end_rejected  |
+                +-------+-------+           +-------+-------+
+                        |                           |
+                      [END]                       [END]
+```
+
+## Agents
+
+### Reviewer Agent (Claude Sonnet)
+
+Performs thorough code review focusing on:
+
+1. **TypeScript Correctness** - Types, generics, annotations
+2. **React Best Practices** - Hooks, Server Components, re-renders
+3. **Accessibility (WCAG AA)** - Semantic HTML, ARIA, keyboard nav
+4. **Performance** - Data fetching, memoization, bundle size
+5. **Security** - XSS, CSRF, secrets exposure
+6. **Code Style** - Naming, structure, organization
+
+### Classifier Agent (Claude Haiku)
+
+Quick classification of PR complexity:
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| TRIVIAL | Docs, deps (minor/patch), formatting | Auto-approve |
+| SIMPLE | Single file <50 lines, tests, config | Quick review |
+| COMPLEX | Multi-file, features, API changes | Full review |
+
+## Policies
+
+| Policy | Max Cost | Max Calls | Timeout |
+|--------|----------|-----------|---------|
+| review_policy | $0.50 | 15 | 300s |
+| triage_policy | $0.05 | 3 | 30s |
+
+## Cost Estimates
+
+| PR Type | Estimated Cost |
+|---------|----------------|
+| Trivial (auto-approve) | ~$0.01 |
+| Simple (quick review) | ~$0.05-0.15 |
+| Complex (full review) | ~$0.15-0.40 |
+
+## Files
+
+```
+agentform/pr-reviewer/
+├── 00-project.af      # Project metadata
+├── 01-variables.af    # API keys and tokens
+├── 02-providers.af    # Anthropic provider and models
+├── 03-servers.af      # MCP GitHub server
+├── 04-capabilities.af # GitHub API capabilities
+├── 05-policies.af     # Cost and timeout limits
+├── 06-agents.af       # Reviewer and classifier agents
+├── 07-workflows.af    # Review workflow definition
+├── input.example.yaml # Example input
+└── README.md          # This file
+```
+
+## Troubleshooting
+
+### "Rate limited" errors
+
+The GitHub MCP server may hit rate limits. Solutions:
+- Use a GitHub App token instead of PAT (higher limits)
+- Add delays between reviews
+- Use `--dry-run` for testing
+
+### "Timeout" errors
+
+Complex PRs may exceed the 300s timeout. Solutions:
+- Increase `timeout_seconds` in `review_policy`
+- Review fewer files per run
+- Split large PRs
+
+### "Cost exceeded" errors
+
+Review stopped due to cost limits. Solutions:
+- Increase `max_cost_usd_per_run` in policies
+- Use `--dry-run` to estimate costs first

--- a/agentform/pr-reviewer/input.example.yaml
+++ b/agentform/pr-reviewer/input.example.yaml
@@ -1,0 +1,11 @@
+# Example input for the review_pr workflow
+# Copy this file to input.yaml and fill in your values
+
+# GitHub repository owner (username or organization)
+owner: "your-org"
+
+# Repository name
+repo: "beads-kanban-ui"
+
+# Pull request number to review
+pull_number: 42


### PR DESCRIPTION
Closes beads-kanban-ui-d1s

Create agentform configuration files for automated PR review using Claude (Anthropic).

Directory: agentform/pr-reviewer/

Files to create:
- 00-project.af: Project metadata
- 01-variables.af: anthropic_api_key, github_personal_access_token
- 02-providers.af: Anthropic provider with claude-sonnet-4 and claude-haiku-4 models
- 03-servers.af: MCP GitHub server config
- 04-capabilities.af: get_pr, list_pr_files, get_file_contents, create_review
- 05-policies.af: review_policy (max $0.50, 300s timeout), triage_policy (max $0.05, 30s)
- 06-agents.af: reviewer (Sonnet, Next.js/React/TS focus), classifier (Haiku, quick complexity check)
- 07-workflows.af: review_pr workflow with classify→route→analyze→approval→submit steps
- input.example.yaml: Example input
- README.md: Setup and usage docs

Key features:
- Uses Claude Sonnet for thorough review, Haiku for quick classification
- Human-in-the-loop approval before posting
- Smart routing: trivial PRs skip detailed review
- Cost controls and timeouts
- Tailored to beads-kanban-ui tech stack (Next.js 14, React 18, TypeScript, Tailwind, shadcn/ui)