### PR TITLE
Rust backend: PR files endpoint

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -125,6 +125,7 @@ async fn main() {
         .route("/api/git/worktrees", get(routes::worktree::list_worktrees))
         // PR endpoints
         .route("/api/git/pr-status", get(routes::worktree::pr_status))
+        .route("/api/git/pr-files", get(routes::worktree::pr_files))
         .route("/api/git/create-pr", post(routes::worktree::create_pr))
         .route("/api/git/merge-pr", post(routes::worktree::merge_pr))
         .route("/api/git/rebase-siblings", post(routes::worktree::rebase_siblings))


### PR DESCRIPTION
Closes beads-kanban-ui-57m.1

Add GET /api/git/pr-files endpoint to worktree.rs that returns the list of changed files for a PR. Uses gh api to fetch PR file data. See design doc .designs/beads-kanban-ui-57m.md for structs and implementation details.