### PR TITLE
feat(api): add agent list and update endpoints

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,10 +121,12 @@ dependencies = [
  "mime_guess",
  "notify",
  "open",
+ "regex",
  "rusqlite",
  "rust-embed",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "tokio",
@@ -259,6 +270,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -456,12 +473,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -574,6 +597,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -924,6 +957,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1137,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1374,6 +1449,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uuid"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,8 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 directories = "5"
+serde_yaml = "0.9"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -10,7 +10,7 @@ use axum::{
     body::Body,
     http::{header, Request, Response, StatusCode},
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{delete, get, post, put},
     Router,
 };
 use rust_embed::Embed;
@@ -129,6 +129,9 @@ async fn main() {
         .route("/api/git/create-pr", post(routes::worktree::create_pr))
         .route("/api/git/merge-pr", post(routes::worktree::merge_pr))
         .route("/api/git/rebase-siblings", post(routes::worktree::rebase_siblings))
+        // Agent endpoints
+        .route("/api/agents", get(routes::agents::list_agents))
+        .route("/api/agents/:filename", put(routes::agents::update_agent))
         // Memory endpoints
         .route(
             "/api/memory",

--- a/server/src/routes/agents.rs
+++ b/server/src/routes/agents.rs
@@ -1,0 +1,596 @@
+//! Agent API route handlers.
+//!
+//! Provides endpoints for listing and updating `.claude/agents/*.md` files.
+//! Each agent file uses YAML frontmatter with fields: name, description, model,
+//! and tools.
+
+use axum::{
+    extract::{Path as AxumPath, Query},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use super::validate_path_security;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Represents the `tools` field in agent frontmatter.
+///
+/// Can be either a wildcard string `"*"` (all tools) or a list of tool names.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum AgentTools {
+    All(String),
+    List(Vec<String>),
+}
+
+/// Information about a single agent parsed from its `.md` file.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentInfo {
+    pub filename: String,
+    pub name: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub tools: Option<AgentTools>,
+    /// The agent's nickname/persona, extracted from the markdown body.
+    #[serde(default)]
+    pub nickname: Option<String>,
+}
+
+/// YAML frontmatter structure as parsed from agent files.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct AgentFrontmatter {
+    pub name: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub tools: Option<AgentTools>,
+}
+
+/// Query parameters for the list agents endpoint.
+#[derive(Debug, Deserialize)]
+pub struct AgentParams {
+    pub path: String,
+}
+
+/// Request body for the update agent endpoint.
+#[derive(Debug, Deserialize)]
+pub struct UpdateAgentBody {
+    pub path: String,
+    pub model: String,
+    #[serde(default)]
+    pub all_tools: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build the path to the agents directory.
+fn agents_dir(project_path: &Path) -> PathBuf {
+    project_path.join(".claude").join("agents")
+}
+
+/// Fix bare `*` in YAML tools field so serde_yaml can parse it.
+///
+/// In agent files, `tools: *` (bare asterisk) is a YAML alias reference and
+/// will cause a parse error. This regex replaces it with `tools: '*'` (quoted).
+fn fix_bare_star(yaml_str: &str) -> String {
+    let re = Regex::new(r"(?m)^(tools:\s*)\*\s*$").unwrap();
+    re.replace_all(yaml_str, r#"$1"*""#).to_string()
+}
+
+/// Split a file's content into YAML frontmatter and markdown body.
+///
+/// Expects the format:
+/// ```text
+/// ---
+/// key: value
+/// ---
+/// # Markdown body...
+/// ```
+///
+/// Returns `(yaml_str, body_str)` or an error if delimiters are not found.
+fn split_frontmatter(content: &str) -> Result<(String, String), String> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return Err("File does not start with YAML frontmatter delimiter".to_string());
+    }
+
+    // Find the closing ---
+    let after_first = &trimmed[3..];
+    let closing_pos = after_first
+        .find("\n---")
+        .ok_or_else(|| "Could not find closing YAML frontmatter delimiter".to_string())?;
+
+    let yaml_str = after_first[..closing_pos].trim().to_string();
+
+    // Body starts after the closing ---
+    let body_start = closing_pos + 4; // skip "\n---"
+    let body = if body_start < after_first.len() {
+        after_first[body_start..].to_string()
+    } else {
+        String::new()
+    };
+
+    Ok((yaml_str, body))
+}
+
+/// Extract a nickname/persona from the markdown body.
+///
+/// Looks for patterns like `# Nickname: "Luna"` or `**Name:** Luna` in the body.
+fn extract_nickname(body: &str) -> Option<String> {
+    // Pattern: **Name:** Something
+    let name_re = Regex::new(r#"\*\*Name:\*\*\s*(.+)"#).ok()?;
+    if let Some(caps) = name_re.captures(body) {
+        let name = caps.get(1)?.as_str().trim().to_string();
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+
+    // Pattern: # Something: "Nickname"
+    let header_re = Regex::new(r#"#\s+\w+.*?:\s*"([^"]+)""#).ok()?;
+    if let Some(caps) = header_re.captures(body) {
+        let name = caps.get(1)?.as_str().trim().to_string();
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+
+    None
+}
+
+/// Parse a single agent file into an `AgentInfo`.
+fn parse_agent_file(filepath: &Path) -> Result<AgentInfo, String> {
+    let filename = filepath
+        .file_name()
+        .and_then(|f| f.to_str())
+        .ok_or_else(|| "Invalid filename".to_string())?
+        .to_string();
+
+    let content = std::fs::read_to_string(filepath)
+        .map_err(|e| format!("Failed to read {}: {}", filename, e))?;
+
+    let (yaml_str, body) = split_frontmatter(&content)?;
+    let yaml_fixed = fix_bare_star(&yaml_str);
+
+    let frontmatter: AgentFrontmatter = serde_yaml::from_str(&yaml_fixed)
+        .map_err(|e| format!("Failed to parse YAML in {}: {}", filename, e))?;
+
+    let nickname = extract_nickname(&body);
+
+    Ok(AgentInfo {
+        filename,
+        name: frontmatter.name,
+        model: frontmatter.model,
+        description: frontmatter.description,
+        tools: frontmatter.tools,
+        nickname,
+    })
+}
+
+/// Validate that a filename is safe (no path traversal, valid characters).
+fn validate_agent_filename(filename: &str) -> Result<(), String> {
+    // Must end with .md
+    if !filename.ends_with(".md") {
+        return Err("Filename must end with .md".to_string());
+    }
+
+    // No path traversal
+    if filename.contains("..") || filename.contains('/') || filename.contains('\\') {
+        return Err("Invalid filename: path traversal not allowed".to_string());
+    }
+
+    // Only allow alphanumeric, hyphens, underscores, and .md extension
+    let stem = filename.trim_end_matches(".md");
+    if stem.is_empty() {
+        return Err("Filename must not be empty".to_string());
+    }
+
+    let valid_re = Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
+    if !valid_re.is_match(stem) {
+        return Err(
+            "Filename must contain only alphanumeric characters, hyphens, and underscores"
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/agents?path={project_path}
+///
+/// Lists all agent files from `.claude/agents/` within the given project path.
+/// Parses YAML frontmatter and extracts agent metadata including nickname.
+pub async fn list_agents(Query(params): Query<AgentParams>) -> impl IntoResponse {
+    let project_path = PathBuf::from(&params.path);
+
+    // Security: Validate path is within allowed directories
+    if let Err(e) = validate_path_security(&project_path) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": e })),
+        );
+    }
+
+    let dir = agents_dir(&project_path);
+
+    if !dir.exists() {
+        return (StatusCode::OK, Json(serde_json::json!([])));
+    }
+
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Failed to read agents directory: {}", e) })),
+            );
+        }
+    };
+
+    let mut agents: Vec<AgentInfo> = Vec::new();
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        let path = entry.path();
+
+        // Only process .md files
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+
+        match parse_agent_file(&path) {
+            Ok(agent) => agents.push(agent),
+            Err(e) => {
+                tracing::warn!("Skipping agent file {:?}: {}", path, e);
+            }
+        }
+    }
+
+    // Sort by name for consistent ordering
+    agents.sort_by(|a, b| a.name.cmp(&b.name));
+
+    (StatusCode::OK, Json(serde_json::json!(agents)))
+}
+
+/// PUT /api/agents/:filename
+///
+/// Updates the model and optionally sets tools to `*` in an agent file.
+/// Preserves the markdown body and other frontmatter fields.
+pub async fn update_agent(
+    AxumPath(filename): AxumPath<String>,
+    Json(payload): Json<UpdateAgentBody>,
+) -> impl IntoResponse {
+    // Validate filename
+    if let Err(e) = validate_agent_filename(&filename) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e })),
+        );
+    }
+
+    let project_path = PathBuf::from(&payload.path);
+
+    // Security: Validate path is within allowed directories
+    if let Err(e) = validate_path_security(&project_path) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": e })),
+        );
+    }
+
+    let file_path = agents_dir(&project_path).join(&filename);
+
+    if !file_path.exists() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": format!("Agent file '{}' not found", filename) })),
+        );
+    }
+
+    let content = match std::fs::read_to_string(&file_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Failed to read file: {}", e) })),
+            );
+        }
+    };
+
+    let (yaml_str, body) = match split_frontmatter(&content) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            );
+        }
+    };
+
+    let yaml_fixed = fix_bare_star(&yaml_str);
+
+    // Parse as serde_yaml::Value so we can modify individual fields
+    let mut yaml_value: serde_yaml::Value = match serde_yaml::from_str(&yaml_fixed) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Failed to parse YAML: {}", e) })),
+            );
+        }
+    };
+
+    // Update model field
+    if let serde_yaml::Value::Mapping(ref mut map) = yaml_value {
+        map.insert(
+            serde_yaml::Value::String("model".to_string()),
+            serde_yaml::Value::String(payload.model.clone()),
+        );
+
+        // Update tools field if all_tools is true
+        if payload.all_tools {
+            map.insert(
+                serde_yaml::Value::String("tools".to_string()),
+                serde_yaml::Value::String("*".to_string()),
+            );
+        }
+    }
+
+    // Serialize YAML back
+    let new_yaml = match serde_yaml::to_string(&yaml_value) {
+        Ok(y) => y,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Failed to serialize YAML: {}", e) })),
+            );
+        }
+    };
+
+    // serde_yaml::to_string adds a trailing newline and no leading ---, so we
+    // need to reassemble with proper delimiters.
+    // Also: serde_yaml quotes '*' as "'*'" which is fine for YAML but we want
+    // the cleaner format `tools: '*'`.
+    let new_yaml_trimmed = new_yaml.trim();
+
+    // Reassemble the file: ---\n{yaml}\n---\n{body}
+    let new_content = format!("---\n{}\n---{}", new_yaml_trimmed, body);
+
+    if let Err(e) = std::fs::write(&file_path, &new_content) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("Failed to write file: {}", e) })),
+        );
+    }
+
+    // Re-parse the updated file and return agent info
+    match parse_agent_file(&file_path) {
+        Ok(agent) => (StatusCode::OK, Json(serde_json::json!(agent))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("Failed to re-read updated file: {}", e) })),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_fix_bare_star() {
+        let input = "name: test\ntools: *\nmodel: opus";
+        let output = fix_bare_star(input);
+        assert!(output.contains(r#"tools: "*""#));
+        assert!(output.contains("name: test"));
+        assert!(output.contains("model: opus"));
+    }
+
+    #[test]
+    fn test_fix_bare_star_already_quoted() {
+        let input = "name: test\ntools: '*'\nmodel: opus";
+        let output = fix_bare_star(input);
+        // Should not double-quote
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_fix_bare_star_list() {
+        let input = "name: test\ntools:\n  - Read\n  - Glob\nmodel: opus";
+        let output = fix_bare_star(input);
+        // Should not change tool lists
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_split_frontmatter() {
+        let content = "---\nname: test\nmodel: opus\n---\n# Hello\n\nBody here.";
+        let (yaml, body) = split_frontmatter(content).unwrap();
+        assert_eq!(yaml, "name: test\nmodel: opus");
+        assert!(body.contains("# Hello"));
+        assert!(body.contains("Body here."));
+    }
+
+    #[test]
+    fn test_split_frontmatter_no_delimiter() {
+        let content = "# No frontmatter here";
+        let result = split_frontmatter(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_nickname_bold_name() {
+        let body = "# Scout: \"Ivy\"\n\n- **Name:** Ivy\n- **Role:** Scout";
+        let nickname = extract_nickname(body);
+        assert_eq!(nickname, Some("Ivy".to_string()));
+    }
+
+    #[test]
+    fn test_extract_nickname_header() {
+        let body = "# Implementation Supervisor: \"Luna\"\n\nSome content";
+        let nickname = extract_nickname(body);
+        // First tries **Name:**, then header pattern
+        assert_eq!(nickname, Some("Luna".to_string()));
+    }
+
+    #[test]
+    fn test_extract_nickname_none() {
+        let body = "# Just a heading\n\nNo nickname pattern here.";
+        let nickname = extract_nickname(body);
+        assert!(nickname.is_none());
+    }
+
+    #[test]
+    fn test_validate_agent_filename_valid() {
+        assert!(validate_agent_filename("scout.md").is_ok());
+        assert!(validate_agent_filename("nextjs-supervisor.md").is_ok());
+        assert!(validate_agent_filename("my_agent.md").is_ok());
+        assert!(validate_agent_filename("Agent123.md").is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_filename_invalid() {
+        assert!(validate_agent_filename("scout.txt").is_err());
+        assert!(validate_agent_filename("../etc/passwd.md").is_err());
+        assert!(validate_agent_filename("path/to/file.md").is_err());
+        assert!(validate_agent_filename(".md").is_err());
+        assert!(validate_agent_filename("bad file.md").is_err());
+        assert!(validate_agent_filename("bad@file.md").is_err());
+    }
+
+    #[test]
+    fn test_parse_agent_file_with_tools_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("scout.md");
+        fs::write(
+            &file_path,
+            "---\nname: scout\ndescription: Codebase exploration\nmodel: haiku\ntools:\n  - Read\n  - Glob\n  - Grep\n---\n\n# Scout: \"Ivy\"\n\n- **Name:** Ivy\n- **Role:** Scout\n",
+        )
+        .unwrap();
+
+        let agent = parse_agent_file(&file_path).unwrap();
+        assert_eq!(agent.filename, "scout.md");
+        assert_eq!(agent.name, "scout");
+        assert_eq!(agent.model, "haiku");
+        assert_eq!(agent.description, "Codebase exploration");
+        assert_eq!(agent.nickname, Some("Ivy".to_string()));
+
+        match agent.tools {
+            Some(AgentTools::List(tools)) => {
+                assert_eq!(tools.len(), 3);
+                assert!(tools.contains(&"Read".to_string()));
+                assert!(tools.contains(&"Glob".to_string()));
+                assert!(tools.contains(&"Grep".to_string()));
+            }
+            _ => panic!("Expected tool list"),
+        }
+    }
+
+    #[test]
+    fn test_parse_agent_file_with_all_tools_quoted() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("supervisor.md");
+        fs::write(
+            &file_path,
+            "---\nname: supervisor\ndescription: Full access\nmodel: opus\ntools: '*'\n---\n\n# Implementation Supervisor: \"Luna\"\n\n- **Name:** Luna\n",
+        )
+        .unwrap();
+
+        let agent = parse_agent_file(&file_path).unwrap();
+        assert_eq!(agent.name, "supervisor");
+        assert_eq!(agent.model, "opus");
+        assert_eq!(agent.nickname, Some("Luna".to_string()));
+
+        match agent.tools {
+            Some(AgentTools::All(s)) => assert_eq!(s, "*"),
+            _ => panic!("Expected AgentTools::All"),
+        }
+    }
+
+    #[test]
+    fn test_parse_agent_file_with_bare_star() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("agent.md");
+        fs::write(
+            &file_path,
+            "---\nname: agent\ndescription: Test\nmodel: sonnet\ntools: *\n---\n\n# Body\n",
+        )
+        .unwrap();
+
+        let agent = parse_agent_file(&file_path).unwrap();
+        assert_eq!(agent.name, "agent");
+        match agent.tools {
+            Some(AgentTools::All(s)) => assert_eq!(s, "*"),
+            _ => panic!("Expected AgentTools::All for bare star"),
+        }
+    }
+
+    #[test]
+    fn test_parse_agent_file_no_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("minimal.md");
+        fs::write(
+            &file_path,
+            "---\nname: minimal\ndescription: Minimal agent\nmodel: haiku\n---\n\n# Body\n",
+        )
+        .unwrap();
+
+        let agent = parse_agent_file(&file_path).unwrap();
+        assert_eq!(agent.name, "minimal");
+        assert!(agent.tools.is_none());
+    }
+
+    #[test]
+    fn test_agents_dir() {
+        let project = PathBuf::from("/home/user/project");
+        let dir = agents_dir(&project);
+        assert_eq!(dir, PathBuf::from("/home/user/project/.claude/agents"));
+    }
+
+    #[test]
+    fn test_agent_tools_serde_list() {
+        let json = r#"["Read","Glob","Grep"]"#;
+        let tools: AgentTools = serde_json::from_str(json).unwrap();
+        match tools {
+            AgentTools::List(v) => assert_eq!(v.len(), 3),
+            _ => panic!("Expected List"),
+        }
+    }
+
+    #[test]
+    fn test_agent_tools_serde_all() {
+        let json = r#""*""#;
+        let tools: AgentTools = serde_json::from_str(json).unwrap();
+        match tools {
+            AgentTools::All(s) => assert_eq!(s, "*"),
+            _ => panic!("Expected All"),
+        }
+    }
+}

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains all HTTP route handlers.
 //! Additional handlers will be added as API endpoints are implemented.
 
+pub mod agents;
 pub mod beads;
 pub mod cli;
 pub mod fs;


### PR DESCRIPTION
## Summary
- Add `GET /api/agents?path=` endpoint to list all `.claude/agents/*.md` files with parsed YAML frontmatter
- Add `PUT /api/agents/:filename` endpoint to update model and tools fields, preserving markdown body
- Handle bare `*` in YAML tools field via regex pre-processing
- 17 unit tests covering parsing, serialization, and edge cases

## Test plan
- [ ] `curl http://localhost:3008/api/agents?path=/path/to/project` returns agent list
- [ ] PUT request updates model field in agent file
- [ ] PUT with `all_tools: true` sets `tools: '*'` in file
- [ ] Cargo test passes (17 agent-specific tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)