### PR TITLE
feat: add Agents panel with model selector and tools toggle

### DIFF
--- a/src/app/project/kanban-board.tsx
+++ b/src/app/project/kanban-board.tsx
@@ -8,6 +8,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
 import { ActivityTimeline } from "@/components/activity-timeline";
+import { AgentsPanel } from "@/components/agents-panel";
 import { BeadDetail } from "@/components/bead-detail";
 import { CommentList } from "@/components/comment-list";
 import { EditableProjectName } from "@/components/editable-project-name";
@@ -102,6 +103,9 @@ export default function KanbanBoard() {
 
   // Memory panel state
   const [isMemoryOpen, setIsMemoryOpen] = useState(false);
+
+  // Agents panel state
+  const [isAgentsOpen, setIsAgentsOpen] = useState(false);
 
   // Show GitHub warning if project loaded, status checked, and either no remote or not authenticated
   const showGitHubWarning = !projectLoading &&
@@ -350,6 +354,9 @@ export default function KanbanBoard() {
           // Memory
           isMemoryOpen={isMemoryOpen}
           onMemoryToggle={() => setIsMemoryOpen((prev) => !prev)}
+          // Agents
+          isAgentsOpen={isAgentsOpen}
+          onAgentsToggle={() => setIsAgentsOpen((prev) => !prev)}
           // Unknown status warning
           unknownStatusCount={unknownStatusBeads.length}
           unknownStatusNames={unknownStatusNames}
@@ -430,6 +437,15 @@ export default function KanbanBoard() {
           onOpenChange={setIsMemoryOpen}
           projectPath={project.path}
           onNavigateToBead={handleMemoryNavigateToBead}
+        />
+      )}
+
+      {/* Agents Panel */}
+      {project?.path && (
+        <AgentsPanel
+          open={isAgentsOpen}
+          onOpenChange={setIsAgentsOpen}
+          projectPath={project.path}
         />
       )}
 

--- a/src/components/agents-panel.tsx
+++ b/src/components/agents-panel.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import { Bot, ChevronDown, Loader2, Wrench } from "lucide-react";
+import { useAgents } from "@/hooks/use-agents";
+import type { Agent, AgentModel } from "@/types";
+
+export interface AgentsPanelProps {
+  /** Whether the panel is open */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Absolute path to the project root */
+  projectPath: string;
+}
+
+/**
+ * Model badge color configuration.
+ * Each model gets a distinct color for quick visual identification.
+ */
+const MODEL_COLORS: Record<
+  AgentModel,
+  { bg: string; text: string; border: string }
+> = {
+  opus: {
+    bg: "bg-orange-500/15",
+    text: "text-orange-400",
+    border: "border-orange-500/25",
+  },
+  sonnet: {
+    bg: "bg-cyan-500/15",
+    text: "text-cyan-400",
+    border: "border-cyan-500/25",
+  },
+  haiku: {
+    bg: "bg-lime-500/15",
+    text: "text-lime-400",
+    border: "border-lime-500/25",
+  },
+};
+
+/** All available model options */
+const MODEL_OPTIONS: AgentModel[] = ["haiku", "sonnet", "opus"];
+
+/**
+ * Format the tools display for collapsed view.
+ */
+function formatToolsSummary(tools: string[] | "*"): string {
+  if (tools === "*") return "All tools";
+  if (tools.length === 0) return "No tools";
+  if (tools.length <= 2) return tools.join(", ");
+  return `${tools.slice(0, 2).join(", ")} +${tools.length - 2}`;
+}
+
+/**
+ * Model badge component for displaying the current model.
+ */
+function ModelBadge({ model }: { model: AgentModel }) {
+  const colors = MODEL_COLORS[model];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-sm px-1.5 py-0.5 text-[0.625rem] leading-none font-medium border",
+        colors.bg,
+        colors.text,
+        colors.border
+      )}
+    >
+      {model}
+    </span>
+  );
+}
+
+/**
+ * Single agent card with collapsible details.
+ */
+function AgentCard({
+  agent,
+  isExpanded,
+  onToggle,
+  onUpdateModel,
+  onToggleAllTools,
+  isUpdating,
+}: {
+  agent: Agent;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onUpdateModel: (model: AgentModel) => void;
+  onToggleAllTools: () => void;
+  isUpdating: boolean;
+}) {
+  const hasAllTools = agent.tools === "*";
+
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 overflow-hidden">
+      {/* Collapsed header - always visible, clickable */}
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isExpanded}
+        className="w-full text-left p-3 flex items-start gap-2.5 hover:bg-zinc-800/30 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset"
+      >
+        <div className="flex-1 min-w-0 space-y-1">
+          {/* Name row */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-zinc-100 truncate">
+              {agent.name}
+            </span>
+            <ModelBadge model={agent.model} />
+          </div>
+
+          {/* Description */}
+          <p className="text-xs text-zinc-500 line-clamp-1 text-pretty">
+            {agent.description || "No description"}
+          </p>
+
+          {/* Tools summary */}
+          <div className="flex items-center gap-1 text-xs text-zinc-500">
+            <Wrench className="size-3 shrink-0" aria-hidden="true" />
+            <span className="truncate">{formatToolsSummary(agent.tools)}</span>
+          </div>
+        </div>
+
+        {/* Expand chevron */}
+        <ChevronDown
+          className={cn(
+            "size-4 text-zinc-500 shrink-0 mt-0.5 transition-transform",
+            isExpanded && "rotate-180"
+          )}
+          aria-hidden="true"
+        />
+      </button>
+
+      {/* Expanded details */}
+      {isExpanded && (
+        <div className="border-t border-zinc-800 p-3 space-y-3">
+          {/* Model selector */}
+          <div className="space-y-1.5">
+            <span id={`model-label-${agent.filename}`} className="text-xs font-medium text-zinc-400">Model</span>
+            <div
+              className="flex gap-1"
+              role="radiogroup"
+              aria-labelledby={`model-label-${agent.filename}`}
+            >
+              {MODEL_OPTIONS.map((model) => {
+                const isSelected = agent.model === model;
+                const colors = MODEL_COLORS[model];
+                return (
+                  <button
+                    key={model}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    disabled={isUpdating}
+                    onClick={() => onUpdateModel(model)}
+                    className={cn(
+                      "flex-1 h-7 rounded-md text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                      isSelected
+                        ? cn(colors.bg, colors.text, "border", colors.border)
+                        : "bg-zinc-800/50 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 border border-transparent"
+                    )}
+                  >
+                    {model}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* All-tools toggle */}
+          <div className="flex items-center justify-between">
+            <label
+              htmlFor={`all-tools-${agent.filename}`}
+              className="text-xs font-medium text-zinc-400"
+            >
+              All tools
+            </label>
+            <button
+              id={`all-tools-${agent.filename}`}
+              type="button"
+              role="switch"
+              aria-checked={hasAllTools}
+              disabled={isUpdating}
+              onClick={onToggleAllTools}
+              className={cn(
+                "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                hasAllTools
+                  ? "bg-orange-500/30 border-orange-500/40"
+                  : "bg-zinc-800 border-zinc-700"
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none block size-3.5 rounded-full transition-transform",
+                  hasAllTools
+                    ? "translate-x-[18px] bg-orange-400"
+                    : "translate-x-[3px] bg-zinc-500"
+                )}
+              />
+            </button>
+          </div>
+
+          {/* Tools list (when not all tools) */}
+          {!hasAllTools && Array.isArray(agent.tools) && agent.tools.length > 0 && (
+            <div className="space-y-1.5">
+              <p className="text-xs font-medium text-zinc-400">
+                Tools ({agent.tools.length})
+              </p>
+              <div className="flex flex-wrap gap-1">
+                {agent.tools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="inline-flex items-center rounded-sm px-1.5 py-0.5 text-[0.625rem] leading-none font-mono bg-zinc-800 text-zinc-500 border border-zinc-700/50"
+                  >
+                    {tool}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Updating indicator */}
+          {isUpdating && (
+            <div role="status" aria-live="polite" className="flex items-center gap-1.5 text-xs text-zinc-500">
+              <Loader2
+                className="size-3 animate-spin"
+                aria-hidden="true"
+              />
+              Saving...
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Agents Panel - slide-out Sheet for browsing and configuring project agents
+ */
+export function AgentsPanel({
+  open,
+  onOpenChange,
+  projectPath,
+}: AgentsPanelProps) {
+  const { agents, isLoading, error, updateAgent } = useAgents(projectPath);
+
+  // Track which card is expanded
+  const [expandedFilename, setExpandedFilename] = useState<string | null>(null);
+
+  // Track which agent is being updated
+  const [updatingFilename, setUpdatingFilename] = useState<string | null>(null);
+
+  /**
+   * Toggle expanded state for a card
+   */
+  const handleToggle = useCallback((filename: string) => {
+    setExpandedFilename((prev) => (prev === filename ? null : filename));
+  }, []);
+
+  /**
+   * Handle model change for an agent
+   */
+  const handleUpdateModel = useCallback(
+    async (agent: Agent, model: AgentModel) => {
+      if (model === agent.model) return;
+      setUpdatingFilename(agent.filename);
+      try {
+        await updateAgent(agent.filename, model, agent.tools === "*");
+      } catch {
+        // Error is logged in hook
+      } finally {
+        setUpdatingFilename(null);
+      }
+    },
+    [updateAgent]
+  );
+
+  /**
+   * Handle all-tools toggle for an agent
+   */
+  const handleToggleAllTools = useCallback(
+    async (agent: Agent) => {
+      const currentlyAllTools = agent.tools === "*";
+      setUpdatingFilename(agent.filename);
+      try {
+        await updateAgent(agent.filename, agent.model, !currentlyAllTools);
+      } catch {
+        // Error is logged in hook
+      } finally {
+        setUpdatingFilename(null);
+      }
+    },
+    [updateAgent]
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-lg md:max-w-xl bg-[#0a0a0a] border-zinc-800 flex flex-col"
+      >
+        <SheetHeader className="space-y-1">
+          <SheetTitle className="flex items-center gap-2 text-zinc-100">
+            <Bot className="size-5" aria-hidden="true" />
+            Agents
+          </SheetTitle>
+          <SheetDescription className="text-zinc-500">
+            {isLoading
+              ? "Loading..."
+              : `${agents.length} ${agents.length === 1 ? "agent" : "agents"}`}
+          </SheetDescription>
+        </SheetHeader>
+
+        {/* Agents list */}
+        <ScrollArea className="flex-1 mt-4 -mx-6 px-6">
+          <div className="space-y-2 pb-4">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2
+                  className="size-5 text-zinc-500 animate-spin"
+                  aria-hidden="true"
+                />
+                <span className="sr-only">Loading agents</span>
+              </div>
+            ) : error ? (
+              <div
+                role="alert"
+                className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-center"
+              >
+                <p className="text-sm text-red-400">
+                  Failed to load agents
+                </p>
+                <p className="text-xs text-red-400/60 mt-1">
+                  {error.message}
+                </p>
+              </div>
+            ) : agents.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <Bot
+                  className="size-8 text-zinc-700 mb-3"
+                  aria-hidden="true"
+                />
+                <p className="text-sm text-zinc-500">No agents configured</p>
+                <p className="text-xs text-zinc-600 mt-1">
+                  Add agent files to .claude/agents/ to get started
+                </p>
+              </div>
+            ) : (
+              agents.map((agent) => (
+                <AgentCard
+                  key={agent.filename}
+                  agent={agent}
+                  isExpanded={expandedFilename === agent.filename}
+                  onToggle={() => handleToggle(agent.filename)}
+                  onUpdateModel={(model) => handleUpdateModel(agent, model)}
+                  onToggleAllTools={() => handleToggleAllTools(agent)}
+                  isUpdating={updatingFilename === agent.filename}
+                />
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/quick-filter-bar.tsx
+++ b/src/components/quick-filter-bar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { Search, X, ArrowUpDown, SlidersHorizontal, BrainCircuit, AlertTriangle } from 'lucide-react';
+import { Search, X, ArrowUpDown, SlidersHorizontal, BrainCircuit, Bot, AlertTriangle } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -68,6 +68,10 @@ interface QuickFilterBarProps {
   isMemoryOpen?: boolean;
   /** Callback to toggle memory panel */
   onMemoryToggle?: () => void;
+  /** Whether the agents panel is open */
+  isAgentsOpen?: boolean;
+  /** Callback to toggle agents panel */
+  onAgentsToggle?: () => void;
   /** Count of beads with truly unknown statuses */
   unknownStatusCount?: number;
   /** List of unknown status names for tooltip */
@@ -118,6 +122,8 @@ export function QuickFilterBar({
   hasActiveFilters,
   isMemoryOpen,
   onMemoryToggle,
+  isAgentsOpen,
+  onAgentsToggle,
   unknownStatusCount = 0,
   unknownStatusNames = [],
 }: QuickFilterBarProps) {
@@ -209,6 +215,24 @@ export function QuickFilterBar({
         >
           <BrainCircuit className="size-4" aria-hidden="true" />
           Memory
+        </button>
+      )}
+
+      {/* Agents Toggle */}
+      {onAgentsToggle && (
+        <button
+          type="button"
+          onClick={onAgentsToggle}
+          aria-pressed={isAgentsOpen}
+          className={cn(
+            'h-8 px-3 text-sm font-medium rounded-md transition-colors flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900',
+            isAgentsOpen
+              ? 'bg-orange-500/20 text-orange-400'
+              : 'bg-zinc-800/50 text-zinc-400 hover:text-zinc-200'
+          )}
+        >
+          <Bot className="size-4" aria-hidden="true" />
+          Agents
         </button>
       )}
 

--- a/src/hooks/use-agents.ts
+++ b/src/hooks/use-agents.ts
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * Hook for loading and managing agent definitions (.claude/agents/*.md).
+ *
+ * Fetches from GET /api/agents and provides update capabilities.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { Agent, AgentModel } from "@/types";
+import * as api from "@/lib/api";
+
+export interface UseAgentsResult {
+  /** All agents for the project */
+  agents: Agent[];
+  /** Whether agents are currently being loaded */
+  isLoading: boolean;
+  /** Any error that occurred during loading */
+  error: Error | null;
+  /** Update an agent's model and/or all-tools setting */
+  updateAgent: (
+    filename: string,
+    model: AgentModel,
+    allTools: boolean
+  ) => Promise<void>;
+  /** Manually refresh agents list */
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Hook to load and manage agent definitions from a project.
+ *
+ * @param projectPath - The absolute path to the project root
+ * @returns Object containing agents, loading state, error, mutations, and refresh
+ */
+export function useAgents(projectPath: string): UseAgentsResult {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Track if initial load has completed
+  const hasLoadedRef = useRef(false);
+
+  /**
+   * Load agents from the API
+   */
+  const loadAgents = useCallback(async () => {
+    if (!projectPath) {
+      setAgents([]);
+      setIsLoading(false);
+      return;
+    }
+
+    // Only show loading on initial load
+    if (!hasLoadedRef.current) {
+      setIsLoading(true);
+    }
+
+    try {
+      const result = await api.agents.list(projectPath);
+      setAgents(result);
+      setError(null);
+      hasLoadedRef.current = true;
+    } catch (err) {
+      const loadError =
+        err instanceof Error ? err : new Error(String(err));
+      setError(loadError);
+      console.error("Failed to load agents:", loadError);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectPath]);
+
+  /**
+   * Public refresh function
+   */
+  const refresh = useCallback(async () => {
+    await loadAgents();
+  }, [loadAgents]);
+
+  // Initial load when project path changes
+  useEffect(() => {
+    hasLoadedRef.current = false;
+    loadAgents();
+  }, [loadAgents]);
+
+  /**
+   * Update an agent's model and/or all-tools setting
+   */
+  const updateAgent = useCallback(
+    async (filename: string, model: AgentModel, allTools: boolean) => {
+      if (!projectPath) return;
+      try {
+        await api.agents.update(filename, projectPath, {
+          model,
+          all_tools: allTools,
+        });
+        await loadAgents();
+      } catch (err) {
+        const updateError =
+          err instanceof Error ? err : new Error(String(err));
+        console.error("Failed to update agent:", updateError);
+        throw updateError;
+      }
+    },
+    [projectPath, loadAgents]
+  );
+
+  return {
+    agents,
+    isLoading,
+    error,
+    updateAgent,
+    refresh,
+  };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@
  * Replaces Tauri invoke() calls with HTTP fetch to backend
  */
 
-import type { Project, Tag, Bead, WorktreeStatus, WorktreeEntry, PRStatus, PRFilesResponse, MemoryResponse, MemoryStats, MemoryEntry } from '@/types';
+import type { Project, Tag, Bead, WorktreeStatus, WorktreeEntry, PRStatus, PRFilesResponse, MemoryResponse, MemoryStats, MemoryEntry, Agent, AgentModel } from '@/types';
 
 const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
 
@@ -328,6 +328,22 @@ export const memory = {
     fetchApi<{ success: boolean; archived: boolean }>('/api/memory', {
       method: 'DELETE',
       body: JSON.stringify({ path, key, archive }),
+    }),
+};
+
+/**
+ * Agents API
+ */
+export const agents = {
+  /** List all agents for a project */
+  list: (path: string) =>
+    fetchApi<Agent[]>(`/api/agents?path=${encodeURIComponent(path)}`),
+
+  /** Update an agent's model or tools configuration */
+  update: (filename: string, path: string, data: { model: AgentModel; all_tools: boolean }) =>
+    fetchApi<Agent>(`/api/agents/${encodeURIComponent(filename)}`, {
+      method: 'PUT',
+      body: JSON.stringify({ path, ...data }),
     }),
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -329,3 +329,30 @@ export interface MemoryResponse {
   entries: MemoryEntry[];
   stats: MemoryStats;
 }
+
+// ============================================================================
+// Agent Types
+// ============================================================================
+
+/**
+ * Supported model names for Claude agents
+ */
+export type AgentModel = "opus" | "sonnet" | "haiku";
+
+/**
+ * An agent definition from .claude/agents/*.md
+ */
+export interface Agent {
+  /** Filename of the agent markdown file (e.g. "reviewer.md") */
+  filename: string;
+  /** Display name of the agent */
+  name: string;
+  /** Model the agent uses */
+  model: AgentModel;
+  /** Description of the agent's role */
+  description: string;
+  /** List of allowed tools, or "*" for all tools */
+  tools: string[] | "*";
+  /** Optional nickname for the agent */
+  nickname: string | null;
+}


### PR DESCRIPTION
## Summary
- Add `AgentsPanel` sheet component with expandable agent cards showing name, model badge, description, and tools
- Add `useAgents` hook for data fetching and agent updates
- Add "Agents" button to QuickFilterBar (Bot icon, orange active state)
- Wire panel state in KanbanBoard
- Model badges: opus (orange), sonnet (cyan), haiku (lime)

Depends on #69 (backend endpoints)

## Test plan
- [ ] Click "Agents" button → panel slides out showing all agents
- [ ] Click agent card → expands to show model selector and all-tools toggle
- [ ] Change model → PUT request fires → badge updates
- [ ] Toggle all-tools → file updated → card reflects change
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)