### PR TITLE
Fix React hydration errors (#418, #423)

### DIFF
--- a/src/components/bead-detail.tsx
+++ b/src/components/bead-detail.tsx
@@ -135,7 +135,7 @@ function formatDate(dateString: string): string {
     const datePart = date.toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
-      year: date.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
+      year: "numeric",
     });
     const timePart = date.toLocaleTimeString("en-US", {
       hour: "2-digit",
@@ -157,7 +157,7 @@ function formatShortDate(dateString: string): string {
     return date.toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
-      year: date.getFullYear() !== new Date().getFullYear() ? "numeric" : undefined,
+      year: "numeric",
     });
   } catch {
     return dateString;

--- a/src/components/memory-panel.tsx
+++ b/src/components/memory-panel.tsx
@@ -139,6 +139,7 @@ function MemoryEntryCard({
         <time
           dateTime={new Date(entry.ts * 1000).toISOString()}
           className="text-xs text-zinc-600 shrink-0 tabular-nums"
+          suppressHydrationWarning
         >
           {formatRelativeTime(entry.ts)}
         </time>


### PR DESCRIPTION
Closes beads-kanban-ui-irw

Issue #66: Multiple SSR/client mismatches cause hydration errors on every page load. Fix all sources: (1) use-pr-settings.ts localStorage state mismatch, (2) bead-detail.tsx new Date().getFullYear() during render, (3) use-bead-filters.ts todayOnly filter using new Date() during render, (4) memory-panel.tsx Date.now() in formatRelativeTime during render.