### PR TITLE
feat: support sync-branch config for issues.jsonl path resolution

### DIFF
--- a/server/src/routes/watch.rs
+++ b/server/src/routes/watch.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{error, info, warn};
 
-use super::beads::recompute_epic_statuses;
+use super::beads::{recompute_epic_statuses, resolve_issues_path};
 
 /// Query parameters for the watch endpoint.
 #[derive(Debug, Deserialize)]
@@ -53,7 +53,7 @@ pub async fn watch_beads(
     Query(params): Query<WatchParams>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     let project_path = PathBuf::from(&params.path);
-    let beads_file = project_path.join(".beads").join("issues.jsonl");
+    let beads_file = resolve_issues_path(&project_path);
 
     info!("Starting file watcher for: {:?}", beads_file);
 


### PR DESCRIPTION
## Summary

- Adds `resolve_issues_path()` that reads `.beads/config.yaml` for `sync-branch` and resolves the correct `issues.jsonl` path
- Replaces hardcoded `.beads/issues.jsonl` at all 3 call sites: `read_beads`, `add_comment`, `watch_beads`
- Graceful fallback to default path when: no config, malformed YAML, empty branch, worktree dir missing
- 12 new unit tests (91 total passing)

Closes #65

## Test plan

- [x] `cargo test` — 91/91 passing
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual test with `sync-branch` configured project
- [ ] Manual test with standard (non-sync-branch) project — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)