### PR TITLE
fix: allow Windows paths on non-system drives (M:\, D:\, etc.)

### DIFF
--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -34,27 +34,20 @@ pub async fn health() -> impl IntoResponse {
     Json(HealthResponse { status: "ok" })
 }
 
-/// Validates that a path is within allowed directories (user home).
+/// Validates that a path is safe to access.
 ///
 /// # Security
 ///
 /// This function ensures that:
-/// - The path is within the user's home directory
-/// - No path traversal attacks are possible
+/// - The path can be canonicalized (no path traversal attacks)
+/// - On Windows: the path is on a local drive (not a UNC network path)
+/// - On Unix: the path is within the user's home directory
 ///
 /// # Returns
 ///
 /// - `Ok(())` if the path is valid and within allowed directories
 /// - `Err(String)` with an error message if validation fails
 pub fn validate_path_security(path: &Path) -> Result<(), String> {
-    // Get the user's home directory
-    let user_dirs = match UserDirs::new() {
-        Some(u) => u,
-        None => return Err("Could not determine user directories".to_string()),
-    };
-
-    let home_dir = user_dirs.home_dir();
-
     // Canonicalize paths for comparison (resolves symlinks and ..)
     let canonical_path = match path.canonicalize() {
         Ok(p) => p,
@@ -71,14 +64,39 @@ pub fn validate_path_security(path: &Path) -> Result<(), String> {
         }
     };
 
-    let canonical_home = match home_dir.canonicalize() {
-        Ok(h) => h,
-        Err(_) => return Err("Could not canonicalize home directory".to_string()),
-    };
+    // On Windows, allow any local drive but block UNC network paths.
+    // On Unix, restrict to the user's home directory.
+    if cfg!(windows) {
+        let path_str = canonical_path.to_string_lossy();
+        // Windows canonicalize produces \\?\C:\... (extended-length path prefix).
+        // Strip that prefix before checking for actual UNC paths.
+        let normalized = path_str
+            .strip_prefix("\\\\?\\")
+            .unwrap_or(&path_str);
+        // Real UNC paths: \\server\share or \\?\UNC\server\share
+        if normalized.starts_with("\\\\") || normalized.starts_with("UNC\\") {
+            return Err("Access denied: network (UNC) paths are not allowed".to_string());
+        }
+        // Must start with a drive letter like C:\
+        if !normalized.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return Err("Access denied: invalid path".to_string());
+        }
+    } else {
+        let user_dirs = match UserDirs::new() {
+            Some(u) => u,
+            None => return Err("Could not determine user directories".to_string()),
+        };
 
-    // Check if the path starts with the home directory
-    if !canonical_path.starts_with(&canonical_home) {
-        return Err("Access denied: path must be within home directory".to_string());
+        let home_dir = user_dirs.home_dir();
+
+        let canonical_home = match home_dir.canonicalize() {
+            Ok(h) => h,
+            Err(_) => return Err("Could not canonicalize home directory".to_string()),
+        };
+
+        if !canonical_path.starts_with(&canonical_home) {
+            return Err("Access denied: path must be within home directory".to_string());
+        }
     }
 
     Ok(())
@@ -101,10 +119,19 @@ mod tests {
     }
 
     #[test]
-    fn test_reject_outside_home() {
-        let result = validate_path_security(&PathBuf::from("/etc/passwd"));
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err();
-        assert!(err_msg.contains("denied") || err_msg.contains("Invalid"));
+    fn test_reject_unsafe_paths() {
+        if cfg!(windows) {
+            // UNC paths should be rejected
+            let result = validate_path_security(&PathBuf::from("\\\\server\\share\\file"));
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err();
+            assert!(err_msg.contains("denied") || err_msg.contains("Invalid") || err_msg.contains("network"));
+        } else {
+            // Unix: paths outside home should be rejected
+            let result = validate_path_security(&PathBuf::from("/etc/passwd"));
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err();
+            assert!(err_msg.contains("denied") || err_msg.contains("Invalid"));
+        }
     }
 }

--- a/src/components/add-project-dialog.tsx
+++ b/src/components/add-project-dialog.tsx
@@ -63,7 +63,7 @@ export function AddProjectDialog({
     setPathError(null);
 
     try {
-      const cleanPath = projectPath.trim().replace(/\/+$/, "");
+      const cleanPath = projectPath.trim().replace(/[/\\]+$/, "");
       const result = await api.fs.exists(`${cleanPath}/.beads`);
 
       if (!result.exists) {
@@ -85,7 +85,10 @@ export function AddProjectDialog({
       setShowNameInput(true);
     } catch (err) {
       console.error("Error validating path:", err);
-      setPathError("Could not access the specified path. Please check it exists.");
+      const message = err instanceof Error ? err.message : String(err);
+      setPathError(message.includes("API error")
+        ? "Could not access the specified path. Please check it exists and is on a local drive."
+        : "Could not access the specified path. Please check it exists.");
     } finally {
       setIsValidating(false);
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -70,7 +70,12 @@ async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
     },
   });
   if (!res.ok) {
-    throw new Error(`API error: ${res.status} ${res.statusText}`);
+    let detail = res.statusText;
+    try {
+      const body = await res.json();
+      if (body?.error) detail = body.error;
+    } catch { /* no JSON body */ }
+    throw new Error(`API error: ${res.status} ${detail}`);
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary

- **Bug:** The "Add Project" dialog returned "Could not access the specified path" on Windows when the project folder was on a non-system drive (e.g. `M:\repos\...`). The `validate_path_security` function only allowed paths under the user's home directory (`C:\Users\...`), rejecting any other drive letter.
- **Fix:** On Windows, the security check now allows any local drive letter while still blocking UNC network paths (`\server\share`). Also correctly handles the `\?\` extended-length prefix that Windows `canonicalize()` adds. On Unix, the original home-directory restriction is preserved.
- **Frontend improvements:** Fixed trailing-slash regex to also strip backslashes (common on Windows), and improved API error propagation so actual server error messages reach the user instead of a generic "403 Forbidden".

### Files changed
- `server/src/routes/mod.rs` — platform-aware path validation
- `src/components/add-project-dialog.tsx` — trailing backslash fix + better error display
- `src/lib/api.ts` — parse JSON error body from server responses

## Test plan
- [x] Verified `GET /api/fs/exists?path=M:\repos\wifi-pentest-ai\.beads` returns `{"exists": true}` (was returning 403)
- [ ] Verify Unix behavior unchanged (home directory restriction still applies)
- [ ] Verify UNC paths (`\server\share`) are still rejected on Windows

---

🤖 Investigated and fixed by [Claude Code](https://claude.ai/claude-code) (claude-opus-4-6)