### PR TITLE
fix: support new bd CLI format for dependencies, parent, and related fields

### DIFF
--- a/server/src/routes/beads.rs
+++ b/server/src/routes/beads.rs
@@ -67,15 +67,24 @@ pub struct BeadsParams {
     pub path: String,
 }
 
-/// A dependency relationship in the JSONL file.
+/// A dependency relationship in the JSONL file (old format).
+///
+/// Old `bd` versions stored dependencies as:
+/// ```json
+/// "dependencies": [{"depends_on_id":"parent-1", "type":"parent-child"}]
+/// ```
 #[derive(Debug, Deserialize, Clone)]
-struct Dependency {
+struct LegacyDependency {
     depends_on_id: String,
     #[serde(rename = "type")]
     dep_type: String,
 }
 
 /// A single bead/issue from the JSONL file.
+///
+/// Supports both old and new `bd` CLI formats:
+/// - **Old**: `dependencies` as array of objects with `depends_on_id` and `type`
+/// - **New**: `parent` (string), `dependencies` as array of string IDs, `related` as array of strings
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Bead {
     pub id: String,
@@ -95,13 +104,13 @@ pub struct Bead {
     pub created_by: Option<String>,
     #[serde(default)]
     pub updated_at: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "closedAt")]
     pub closed_at: Option<String>,
     #[serde(default)]
     pub close_reason: Option<String>,
     #[serde(default)]
     pub comments: Option<Vec<Comment>>,
-    #[serde(default)]
+    #[serde(default, alias = "parent")]
     pub parent_id: Option<String>,
     #[serde(default)]
     pub children: Option<Vec<String>>,
@@ -109,10 +118,50 @@ pub struct Bead {
     pub design_doc: Option<String>,
     #[serde(default)]
     pub deps: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, alias = "related")]
     pub relates_to: Option<Vec<String>>,
-    #[serde(default, skip_serializing)]
-    dependencies: Option<Vec<Dependency>>,
+    /// Raw dependencies field — accepts both old (array of objects) and new (array of strings) formats.
+    #[serde(default, skip_serializing, deserialize_with = "deserialize_dependencies")]
+    dependencies: Option<RawDependencies>,
+}
+
+/// Parsed dependencies in either old or new format.
+#[derive(Debug, Clone)]
+enum RawDependencies {
+    /// Old format: array of `{depends_on_id, type}` objects
+    Legacy(Vec<LegacyDependency>),
+    /// New format: flat array of string IDs (blocking deps)
+    StringIds(Vec<String>),
+}
+
+/// Custom deserializer that handles both old and new dependency formats.
+fn deserialize_dependencies<'de, D>(deserializer: D) -> Result<Option<RawDependencies>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<serde_json::Value> = Option::deserialize(deserializer)?;
+    let arr = match value {
+        Some(serde_json::Value::Array(a)) => a,
+        Some(serde_json::Value::Null) | None => return Ok(None),
+        _ => return Err(serde::de::Error::custom("expected array or null for dependencies")),
+    };
+
+    if arr.is_empty() {
+        return Ok(None);
+    }
+
+    // Check first element to distinguish formats
+    if arr[0].is_string() {
+        // New format: ["id1", "id2"]
+        let ids: Vec<String> = serde_json::from_value(serde_json::Value::Array(arr))
+            .map_err(serde::de::Error::custom)?;
+        Ok(Some(RawDependencies::StringIds(ids)))
+    } else {
+        // Old format: [{depends_on_id, type}, ...]
+        let deps: Vec<LegacyDependency> = serde_json::from_value(serde_json::Value::Array(arr))
+            .map_err(serde::de::Error::custom)?;
+        Ok(Some(RawDependencies::Legacy(deps)))
+    }
 }
 
 /// A comment on a bead.
@@ -183,26 +232,65 @@ pub async fn read_beads(Query(params): Query<BeadsParams>) -> impl IntoResponse 
         }
     }
 
-    // Post-process: Transform dependencies into parent_id and children
+    // Post-process: Transform dependencies into parent_id, deps, relates_to, and children
     // Build a map of parent_id -> Vec<child_id>
     let mut parent_to_children: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
 
-    // First pass: Extract parent-child relationships from explicit dependencies
+    // First pass: Extract relationships from dependencies (both old and new format)
     for bead in &mut beads {
-        if let Some(deps) = &bead.dependencies {
-            for dep in deps {
-                if dep.dep_type == "parent-child" {
-                    // Set parent_id on this bead
-                    bead.parent_id = Some(dep.depends_on_id.clone());
-                    // Record this bead as a child of the parent
-                    parent_to_children
-                        .entry(dep.depends_on_id.clone())
-                        .or_default()
-                        .push(bead.id.clone());
+        if let Some(raw_deps) = bead.dependencies.take() {
+            match raw_deps {
+                RawDependencies::Legacy(legacy_deps) => {
+                    // Old format: extract parent-child, relates-to, and blocking deps
+                    let mut blocking = Vec::new();
+                    let mut related = Vec::new();
+                    for dep in &legacy_deps {
+                        match dep.dep_type.as_str() {
+                            "parent-child" => {
+                                bead.parent_id = Some(dep.depends_on_id.clone());
+                                parent_to_children
+                                    .entry(dep.depends_on_id.clone())
+                                    .or_default()
+                                    .push(bead.id.clone());
+                            }
+                            "relates-to" => {
+                                related.push(dep.depends_on_id.clone());
+                            }
+                            _ => {
+                                blocking.push(dep.depends_on_id.clone());
+                            }
+                        }
+                    }
+                    if !blocking.is_empty() && bead.deps.is_none() {
+                        bead.deps = Some(blocking);
+                    }
+                    if !related.is_empty() && bead.relates_to.is_none() {
+                        bead.relates_to = Some(related);
+                    }
+                }
+                RawDependencies::StringIds(ids) => {
+                    // New format: dependencies are blocking deps (parent comes from `parent` field)
+                    if !ids.is_empty() && bead.deps.is_none() {
+                        bead.deps = Some(ids);
+                    }
                 }
             }
         }
+
+        // Record parent-child from `parent` field (new format, already deserialized via alias)
+        if let Some(parent_id) = &bead.parent_id {
+            parent_to_children
+                .entry(parent_id.clone())
+                .or_default()
+                .push(bead.id.clone());
+        }
+    }
+
+    // Deduplicate parent_to_children entries (in case both old dependencies and parent field set)
+    for children in parent_to_children.values_mut() {
+        children.sort();
+        children.dedup();
     }
 
     // Second pass: Infer parent-child from ID patterns (e.g., "64n.1" -> parent "64n")
@@ -248,20 +336,6 @@ pub async fn read_beads(Query(params): Query<BeadsParams>) -> impl IntoResponse 
     for bead in &mut beads {
         if let Some(children) = parent_to_children.get(&bead.id) {
             bead.children = Some(children.clone());
-        }
-    }
-
-    // Fourth pass: Extract relates-to dependencies into relates_to field
-    for bead in &mut beads {
-        if let Some(deps) = &bead.dependencies {
-            let related: Vec<String> = deps
-                .iter()
-                .filter(|dep| dep.dep_type == "relates-to")
-                .map(|dep| dep.depends_on_id.clone())
-                .collect();
-            if !related.is_empty() {
-                bead.relates_to = Some(related);
-            }
         }
     }
 
@@ -553,16 +627,25 @@ pub fn recompute_epic_statuses(issues_path: &Path) -> Result<Vec<String>, String
     // parent_id -> Vec<child_id>
     let mut parent_to_children: HashMap<String, Vec<String>> = HashMap::new();
 
-    // First pass: Extract from explicit dependencies
-    for bead in &beads {
-        if let Some(deps) = &bead.dependencies {
-            for dep in deps {
+    // First pass: Extract from explicit dependencies and parent field
+    for bead in &mut beads {
+        if let Some(RawDependencies::Legacy(legacy_deps)) = bead.dependencies.take() {
+            for dep in &legacy_deps {
                 if dep.dep_type == "parent-child" {
+                    bead.parent_id = Some(dep.depends_on_id.clone());
                     parent_to_children
                         .entry(dep.depends_on_id.clone())
                         .or_default()
                         .push(bead.id.clone());
                 }
+            }
+        }
+
+        // Record parent-child from `parent` field (new format)
+        if let Some(parent_id) = &bead.parent_id {
+            let children = parent_to_children.entry(parent_id.clone()).or_default();
+            if !children.contains(&bead.id) {
+                children.push(bead.id.clone());
             }
         }
     }
@@ -805,117 +888,60 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_bead_with_relates_to_dependencies() {
-        // Test that relates-to dependencies are deserialized from the dependencies array
-        let json = r#"{"id":"bead-a","title":"Bead A","status":"open","dependencies":[{"issue_id":"bead-a","depends_on_id":"bead-b","type":"relates-to","created_at":"2026-01-27T00:00:00Z","created_by":"user"},{"issue_id":"bead-a","depends_on_id":"bead-c","type":"relates-to","created_at":"2026-01-27T00:00:00Z","created_by":"user"}]}"#;
+    fn test_parse_old_format_dependencies() {
+        // Old format: dependencies as array of objects
+        let json = r#"{"id":"bead-a","title":"Bead A","status":"open","dependencies":[{"issue_id":"bead-a","depends_on_id":"bead-b","type":"relates-to","created_at":"2026-01-27T00:00:00Z","created_by":"user"},{"issue_id":"bead-a","depends_on_id":"bead-c","type":"parent-child","created_at":"2026-01-27T00:00:00Z","created_by":"user"}]}"#;
         let bead: Bead = serde_json::from_str(json).unwrap();
-        let deps = bead.dependencies.unwrap();
-        assert_eq!(deps.len(), 2);
-        assert_eq!(deps[0].dep_type, "relates-to");
-        assert_eq!(deps[0].depends_on_id, "bead-b");
-        assert_eq!(deps[1].dep_type, "relates-to");
-        assert_eq!(deps[1].depends_on_id, "bead-c");
+        assert!(bead.dependencies.is_some());
+        if let Some(RawDependencies::Legacy(deps)) = &bead.dependencies {
+            assert_eq!(deps.len(), 2);
+            assert_eq!(deps[0].dep_type, "relates-to");
+            assert_eq!(deps[0].depends_on_id, "bead-b");
+            assert_eq!(deps[1].dep_type, "parent-child");
+        } else {
+            panic!("Expected Legacy dependencies");
+        }
     }
 
     #[test]
-    fn test_relates_to_extraction_logic() {
-        // Test the fourth pass extraction logic that populates relates_to from dependencies
-        let mut bead = Bead {
-            id: "bead-a".to_string(),
-            title: "Bead A".to_string(),
-            description: None,
-            status: "open".to_string(),
-            priority: None,
-            issue_type: None,
-            owner: None,
-            created_at: None,
-            created_by: None,
-            updated_at: None,
-            closed_at: None,
-            close_reason: None,
-            comments: None,
-            parent_id: None,
-            children: None,
-            design_doc: None,
-            deps: None,
-            relates_to: None,
-            dependencies: Some(vec![
-                Dependency {
-                    depends_on_id: "bead-b".to_string(),
-                    dep_type: "relates-to".to_string(),
-                },
-                Dependency {
-                    depends_on_id: "bead-parent".to_string(),
-                    dep_type: "parent-child".to_string(),
-                },
-                Dependency {
-                    depends_on_id: "bead-c".to_string(),
-                    dep_type: "relates-to".to_string(),
-                },
-            ]),
-        };
-
-        // Simulate the fourth pass extraction logic
-        if let Some(deps) = &bead.dependencies {
-            let related: Vec<String> = deps
-                .iter()
-                .filter(|dep| dep.dep_type == "relates-to")
-                .map(|dep| dep.depends_on_id.clone())
-                .collect();
-            if !related.is_empty() {
-                bead.relates_to = Some(related);
-            }
+    fn test_parse_new_format_dependencies() {
+        // New format: dependencies as array of strings
+        let json = r#"{"id":"task-71","title":"New Task","status":"open","parent":"epic-65","dependencies":["task-67"],"related":["task-35"]}"#;
+        let bead: Bead = serde_json::from_str(json).unwrap();
+        // parent field should be deserialized into parent_id
+        assert_eq!(bead.parent_id, Some("epic-65".to_string()));
+        // related field should be deserialized into relates_to
+        assert_eq!(bead.relates_to, Some(vec!["task-35".to_string()]));
+        // dependencies should be parsed as StringIds
+        if let Some(RawDependencies::StringIds(ids)) = &bead.dependencies {
+            assert_eq!(ids, &vec!["task-67".to_string()]);
+        } else {
+            panic!("Expected StringIds dependencies");
         }
-
-        // Verify only relates-to deps are extracted, not parent-child
-        let relates_to = bead.relates_to.unwrap();
-        assert_eq!(relates_to.len(), 2);
-        assert_eq!(relates_to[0], "bead-b");
-        assert_eq!(relates_to[1], "bead-c");
     }
 
     #[test]
-    fn test_relates_to_none_when_no_relates_to_deps() {
-        // Test that relates_to stays None when there are no relates-to dependencies
-        let mut bead = Bead {
-            id: "bead-x".to_string(),
-            title: "Bead X".to_string(),
-            description: None,
-            status: "open".to_string(),
-            priority: None,
-            issue_type: None,
-            owner: None,
-            created_at: None,
-            created_by: None,
-            updated_at: None,
-            closed_at: None,
-            close_reason: None,
-            comments: None,
-            parent_id: None,
-            children: None,
-            design_doc: None,
-            deps: None,
-            relates_to: None,
-            dependencies: Some(vec![Dependency {
-                depends_on_id: "bead-parent".to_string(),
-                dep_type: "parent-child".to_string(),
-            }]),
-        };
+    fn test_parse_new_format_closed_at_camel_case() {
+        // New format uses closedAt instead of closed_at
+        let json = r#"{"id":"task-67","title":"Done","status":"closed","closedAt":"2026-02-28T12:53:27.963Z"}"#;
+        let bead: Bead = serde_json::from_str(json).unwrap();
+        assert_eq!(bead.closed_at, Some("2026-02-28T12:53:27.963Z".to_string()));
+    }
 
-        // Simulate the fourth pass extraction logic
-        if let Some(deps) = &bead.dependencies {
-            let related: Vec<String> = deps
-                .iter()
-                .filter(|dep| dep.dep_type == "relates-to")
-                .map(|dep| dep.depends_on_id.clone())
-                .collect();
-            if !related.is_empty() {
-                bead.relates_to = Some(related);
-            }
-        }
+    #[test]
+    fn test_parse_empty_dependencies_array() {
+        // Empty dependencies array should parse as None
+        let json = r#"{"id":"task-1","title":"No deps","status":"open","dependencies":[]}"#;
+        let bead: Bead = serde_json::from_str(json).unwrap();
+        assert!(bead.dependencies.is_none());
+    }
 
-        // No relates-to deps, so relates_to should remain None
-        assert!(bead.relates_to.is_none());
+    #[test]
+    fn test_parse_no_dependencies_field() {
+        // Missing dependencies field should parse fine
+        let json = r#"{"id":"task-2","title":"Simple","status":"open"}"#;
+        let bead: Bead = serde_json::from_str(json).unwrap();
+        assert!(bead.dependencies.is_none());
     }
 
     #[test]
@@ -941,10 +967,7 @@ mod tests {
             design_doc: None,
             deps: None,
             relates_to: Some(vec!["bead-r1".to_string(), "bead-r2".to_string()]),
-            dependencies: Some(vec![Dependency {
-                depends_on_id: "bead-r1".to_string(),
-                dep_type: "relates-to".to_string(),
-            }]),
+            dependencies: None,
         };
 
         let json = serde_json::to_string(&bead).unwrap();
@@ -956,7 +979,29 @@ mod tests {
 
         // dependencies should NOT be serialized (skip_serializing)
         assert!(!json.contains("dependencies"));
-        assert!(!json.contains("depends_on_id"));
+    }
+
+    #[test]
+    fn test_parse_real_new_format_line() {
+        // Real line from updated bd CLI
+        let json = r#"{"id":"ai-photo-factory-71","title":"Миграция лендинга","description":"Описание задачи","status":"open","priority":2,"issue_type":"task","owner":"user@email.com","created_at":"2026-02-28T11:30:26.430Z","created_by":"weselow","updated_at":"2026-02-28T11:30:26.430Z","parent":"ai-photo-factory-65","dependencies":["ai-photo-factory-67"]}"#;
+        let bead: Bead = serde_json::from_str(json).unwrap();
+        assert_eq!(bead.id, "ai-photo-factory-71");
+        assert_eq!(bead.parent_id, Some("ai-photo-factory-65".to_string()));
+        if let Some(RawDependencies::StringIds(ids)) = &bead.dependencies {
+            assert_eq!(ids, &vec!["ai-photo-factory-67".to_string()]);
+        } else {
+            panic!("Expected StringIds dependencies");
+        }
+    }
+
+    #[test]
+    fn test_parse_new_format_with_related() {
+        // New format with related field
+        let json = r#"{"id":"task-75","title":"Post-processing","status":"open","parent":"epic-65","dependencies":["task-66"],"related":["task-35"]}"#;
+        let bead: Bead = serde_json::from_str(json).unwrap();
+        assert_eq!(bead.relates_to, Some(vec!["task-35".to_string()]));
+        assert_eq!(bead.parent_id, Some("epic-65".to_string()));
     }
 
     // ── resolve_issues_path tests ──────────────────────────────────────

--- a/server/src/routes/beads.rs
+++ b/server/src/routes/beads.rs
@@ -411,8 +411,9 @@ pub async fn add_comment(Json(payload): Json<AddCommentRequest>) -> impl IntoRes
         }
     };
 
-    // Parse JSONL and find the target bead
-    let mut beads: Vec<Bead> = Vec::new();
+    // Parse JSONL as raw JSON values to preserve original field names and structure.
+    // We also parse as Bead to find the target and track comment IDs.
+    let mut raw_lines: Vec<serde_json::Value> = Vec::new();
     let mut found_bead_index: Option<usize> = None;
     let mut max_comment_id: i64 = 0;
 
@@ -422,30 +423,30 @@ pub async fn add_comment(Json(payload): Json<AddCommentRequest>) -> impl IntoRes
             continue;
         }
 
-        match serde_json::from_str::<Bead>(line) {
-            Ok(bead) => {
-                // Track the maximum comment ID across all beads
-                if let Some(comments) = &bead.comments {
-                    for comment in comments {
-                        if comment.id > max_comment_id {
-                            max_comment_id = comment.id;
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(value) => {
+                // Parse as Bead to extract typed info
+                if let Ok(bead) = serde_json::from_value::<Bead>(value.clone()) {
+                    if let Some(comments) = &bead.comments {
+                        for comment in comments {
+                            if comment.id > max_comment_id {
+                                max_comment_id = comment.id;
+                            }
                         }
                     }
+                    if bead.id == payload.bead_id {
+                        found_bead_index = Some(raw_lines.len());
+                    }
                 }
-
-                if bead.id == payload.bead_id {
-                    found_bead_index = Some(beads.len());
-                }
-                beads.push(bead);
+                raw_lines.push(value);
             }
             Err(e) => {
                 tracing::warn!(
-                    "Failed to parse bead at line {}: {} - {}",
+                    "Failed to parse line {}: {} - {}",
                     line_num + 1,
                     e,
                     line
                 );
-                // Continue parsing other lines - graceful handling of malformed lines
             }
         }
     }
@@ -465,23 +466,27 @@ pub async fn add_comment(Json(payload): Json<AddCommentRequest>) -> impl IntoRes
         }
     };
 
-    // Create the new comment
-    let new_comment = Comment {
-        id: max_comment_id + 1,
-        issue_id: payload.bead_id.clone(),
-        author: payload.author,
-        text: payload.text,
-        created_at: Utc::now().to_rfc3339(),
-    };
+    // Create the new comment as a JSON value
+    let new_comment = serde_json::json!({
+        "id": max_comment_id + 1,
+        "issue_id": payload.bead_id,
+        "author": payload.author,
+        "text": payload.text,
+        "created_at": Utc::now().to_rfc3339(),
+    });
 
-    // Add the comment to the bead
-    let bead = &mut beads[bead_index];
-    match &mut bead.comments {
-        Some(comments) => comments.push(new_comment),
-        None => bead.comments = Some(vec![new_comment]),
+    // Add the comment to the raw JSON value (preserving all original fields)
+    let raw_bead = &mut raw_lines[bead_index];
+    if let Some(obj) = raw_bead.as_object_mut() {
+        let comments = obj
+            .entry("comments")
+            .or_insert_with(|| serde_json::json!([]));
+        if let Some(arr) = comments.as_array_mut() {
+            arr.push(new_comment);
+        }
     }
 
-    // Write the updated beads back to the file
+    // Write all raw JSON values back to the file (preserving original format)
     let file = match std::fs::File::create(&issues_path) {
         Ok(f) => f,
         Err(e) => {
@@ -497,8 +502,8 @@ pub async fn add_comment(Json(payload): Json<AddCommentRequest>) -> impl IntoRes
     };
 
     let mut writer = std::io::BufWriter::new(file);
-    for bead in &beads {
-        match serde_json::to_string(bead) {
+    for value in &raw_lines {
+        match serde_json::to_string(value) {
             Ok(json_line) => {
                 if let Err(e) = writeln!(writer, "{}", json_line) {
                     return (
@@ -517,7 +522,7 @@ pub async fn add_comment(Json(payload): Json<AddCommentRequest>) -> impl IntoRes
                     Json(AddCommentResponse {
                         success: false,
                         bead: None,
-                        error: Some(format!("Failed to serialize bead: {}", e)),
+                        error: Some(format!("Failed to serialize: {}", e)),
                     }),
                 );
             }
@@ -535,13 +540,14 @@ pub async fn add_comment(Json(payload): Json<AddCommentRequest>) -> impl IntoRes
         );
     }
 
-    // Return the updated bead
-    let updated_bead = beads.swap_remove(bead_index);
+    // Return the updated bead (parsed from the modified raw JSON)
+    let updated_bead = serde_json::from_value::<Bead>(raw_lines.swap_remove(bead_index))
+        .ok();
     (
         StatusCode::OK,
         Json(AddCommentResponse {
             success: true,
-            bead: Some(updated_bead),
+            bead: updated_bead,
             error: None,
         }),
     )
@@ -602,7 +608,8 @@ pub fn recompute_epic_statuses(issues_path: &Path) -> Result<Vec<String>, String
     let contents = std::fs::read_to_string(issues_path)
         .map_err(|e| format!("Failed to read file: {}", e))?;
 
-    // Parse JSONL into beads
+    // Parse JSONL as both raw Values (for lossless write-back) and Beads (for logic)
+    let mut raw_lines: Vec<serde_json::Value> = Vec::new();
     let mut beads: Vec<Bead> = Vec::new();
     for (line_num, line) in contents.lines().enumerate() {
         let line = line.trim();
@@ -610,27 +617,37 @@ pub fn recompute_epic_statuses(issues_path: &Path) -> Result<Vec<String>, String
             continue;
         }
 
-        match serde_json::from_str::<Bead>(line) {
-            Ok(bead) => beads.push(bead),
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(value) => {
+                match serde_json::from_value::<Bead>(value.clone()) {
+                    Ok(bead) => beads.push(bead),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to parse bead at line {}: {}",
+                            line_num + 1,
+                            e
+                        );
+                    }
+                }
+                raw_lines.push(value);
+            }
             Err(e) => {
                 tracing::warn!(
-                    "Failed to parse bead at line {}: {} - {}",
+                    "Failed to parse JSON at line {}: {}",
                     line_num + 1,
-                    e,
-                    line
+                    e
                 );
             }
         }
     }
 
     // Build parent-child relationships
-    // parent_id -> Vec<child_id>
     let mut parent_to_children: HashMap<String, Vec<String>> = HashMap::new();
 
-    // First pass: Extract from explicit dependencies and parent field
+    // First pass: Extract from dependencies and parent field
     for bead in &mut beads {
-        if let Some(RawDependencies::Legacy(legacy_deps)) = bead.dependencies.take() {
-            for dep in &legacy_deps {
+        if let Some(RawDependencies::Legacy(ref legacy_deps)) = bead.dependencies {
+            for dep in legacy_deps {
                 if dep.dep_type == "parent-child" {
                     bead.parent_id = Some(dep.depends_on_id.clone());
                     parent_to_children
@@ -641,7 +658,6 @@ pub fn recompute_epic_statuses(issues_path: &Path) -> Result<Vec<String>, String
             }
         }
 
-        // Record parent-child from `parent` field (new format)
         if let Some(parent_id) = &bead.parent_id {
             let children = parent_to_children.entry(parent_id.clone()).or_default();
             if !children.contains(&bead.id) {
@@ -650,17 +666,14 @@ pub fn recompute_epic_statuses(issues_path: &Path) -> Result<Vec<String>, String
         }
     }
 
-    // Second pass: Infer parent-child from ID patterns (e.g., "64n.1" -> parent "64n")
-    // This matches how the bd CLI infers relationships when parent_id is not set
+    // Second pass: Infer parent-child from ID patterns
     let bead_ids: std::collections::HashSet<String> =
         beads.iter().map(|b| b.id.clone()).collect();
 
     for bead in &beads {
-        // Only infer if not already in parent_to_children
         if bead.parent_id.is_none() && bead.id.contains('.') {
             if let Some(dot_pos) = bead.id.rfind('.') {
                 let potential_parent = &bead.id[..dot_pos];
-                // Only infer if parent exists and not already recorded
                 if bead_ids.contains(potential_parent) {
                     let children = parent_to_children
                         .entry(potential_parent.to_string())
@@ -673,39 +686,30 @@ pub fn recompute_epic_statuses(issues_path: &Path) -> Result<Vec<String>, String
         }
     }
 
-    // Build a map of bead_id -> status for quick lookup (owned strings to avoid borrow issues)
+    // Build status map
     let status_map: HashMap<String, String> = beads
         .iter()
         .map(|b| (b.id.clone(), b.status.clone()))
         .collect();
 
-    // First pass: find which epics need updates
+    // Find which epics need updates
     let mut epic_updates: Vec<(String, String)> = Vec::new();
 
     for bead in &beads {
-        // Only process epics
         if bead.issue_type.as_deref() != Some("epic") {
             continue;
         }
-
-        // Skip closed epics - don't auto-reopen them
         if bead.status == "closed" {
             continue;
         }
-
-        // Get children for this epic
         let children = match parent_to_children.get(&bead.id) {
             Some(c) => c,
-            None => continue, // No children, skip
+            None => continue,
         };
-
-        // Collect child statuses
         let child_statuses: Vec<&str> = children
             .iter()
             .filter_map(|child_id| status_map.get(child_id).map(String::as_str))
             .collect();
-
-        // Compute the new status
         if let Some(new_status) = compute_epic_status_from_children(&child_statuses) {
             if bead.status != new_status {
                 epic_updates.push((bead.id.clone(), new_status.to_string()));
@@ -713,35 +717,36 @@ pub fn recompute_epic_statuses(issues_path: &Path) -> Result<Vec<String>, String
         }
     }
 
-    // Second pass: apply updates
+    // Apply updates to raw JSON values (preserving original field names)
     let mut updated_epic_ids: Vec<String> = Vec::new();
 
     for (epic_id, new_status) in &epic_updates {
-        for bead in &mut beads {
-            if &bead.id == epic_id {
-                tracing::info!(
-                    "Updating epic {} status from {} to {}",
-                    bead.id,
-                    bead.status,
-                    new_status
-                );
-                bead.status = new_status.clone();
-                bead.updated_at = Some(Utc::now().to_rfc3339());
-                updated_epic_ids.push(bead.id.clone());
-                break;
+        for value in &mut raw_lines {
+            if let Some(obj) = value.as_object_mut() {
+                if obj.get("id").and_then(|v| v.as_str()) == Some(epic_id) {
+                    tracing::info!(
+                        "Updating epic {} status to {}",
+                        epic_id,
+                        new_status
+                    );
+                    obj.insert("status".to_string(), serde_json::json!(new_status));
+                    obj.insert("updated_at".to_string(), serde_json::json!(Utc::now().to_rfc3339()));
+                    updated_epic_ids.push(epic_id.clone());
+                    break;
+                }
             }
         }
     }
 
-    // Write back if any epic was updated
+    // Write back if any epic was updated (using raw values to preserve format)
     if !updated_epic_ids.is_empty() {
         let file = std::fs::File::create(issues_path)
             .map_err(|e| format!("Failed to open file for writing: {}", e))?;
 
         let mut writer = std::io::BufWriter::new(file);
-        for bead in &beads {
-            let json_line = serde_json::to_string(bead)
-                .map_err(|e| format!("Failed to serialize bead: {}", e))?;
+        for value in &raw_lines {
+            let json_line = serde_json::to_string(value)
+                .map_err(|e| format!("Failed to serialize: {}", e))?;
             writeln!(writer, "{}", json_line)
                 .map_err(|e| format!("Failed to write to file: {}", e))?;
         }
@@ -1002,6 +1007,33 @@ mod tests {
         let bead: Bead = serde_json::from_str(json).unwrap();
         assert_eq!(bead.relates_to, Some(vec!["task-35".to_string()]));
         assert_eq!(bead.parent_id, Some("epic-65".to_string()));
+    }
+
+    #[test]
+    fn test_roundtrip_via_raw_value_preserves_format() {
+        // Simulate what add_comment and recompute_epic_statuses now do:
+        // parse as serde_json::Value, modify, write back
+        let input = r#"{"id":"task-71","title":"Migration","status":"open","parent":"epic-65","dependencies":["task-67"],"related":["task-35"],"closedAt":"2026-02-28T12:00:00Z"}"#;
+
+        // Parse as raw Value (as server now does)
+        let value: serde_json::Value = serde_json::from_str(input).unwrap();
+
+        // Serialize back
+        let output = serde_json::to_string(&value).unwrap();
+
+        println!("INPUT:  {}", input);
+        println!("OUTPUT: {}", output);
+
+        // All original field names must be preserved
+        assert!(output.contains("\"parent\":\"epic-65\""), "parent field preserved");
+        assert!(output.contains("\"dependencies\":[\"task-67\"]"), "dependencies preserved");
+        assert!(output.contains("\"related\":[\"task-35\"]"), "related field preserved");
+        assert!(output.contains("\"closedAt\":\"2026-02-28T12:00:00Z\""), "closedAt preserved");
+
+        // No mangled field names
+        assert!(!output.contains("parent_id"), "no parent_id in output");
+        assert!(!output.contains("relates_to"), "no relates_to in output");
+        assert!(!output.contains("closed_at"), "no closed_at in output");
     }
 
     // ── resolve_issues_path tests ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Recent `bd` CLI versions changed the `issues.jsonl` format. The server's parser expected `dependencies` as an array of objects, but the new format uses a flat array of string IDs. This caused all beads written in the new format to be silently dropped — they simply didn't appear on the dashboard.

Changes in the new `bd` format:
| Field | Old format | New format |
|---|---|---|
| Parent | `"dependencies": [{"type":"parent-child", "depends_on_id":"..."}]` | `"parent": "epic-65"` |
| Blocking deps | `"dependencies": [{"type":"blocks", "depends_on_id":"..."}]` | `"dependencies": ["task-67"]` |
| Related | `"dependencies": [{"type":"relates-to", "depends_on_id":"..."}]` | `"related": ["task-35"]` |
| Closed date | `"closed_at"` | `"closedAt"` |

The fix adds a custom serde deserializer that handles both old and new formats, plus field aliases (`parent` -> `parent_id`, `related` -> `relates_to`, `closedAt` -> `closed_at`). Full backward compatibility is preserved.

- Only `server/src/routes/beads.rs` is modified
- 95 tests pass (including 8 new tests for the new format)

## Note on open PRs

This PR, #84 (folder browser), and #82 (Windows path fix) are fully independent — they touch different files with no overlaps. They can be reviewed and merged in any order without conflicts.

## A personal request

I've been actively using Beads Kanban UI and fixing issues as I go. I understand you're busy and may not have much time to maintain this project right now. Would you consider adding me as a maintainer? I'd be happy to continue improving it, reviewing PRs, and keeping things up to date as `bd` evolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)