### PR TITLE
Default API_BASE to same-origin instead of hardcoded localhost:3008

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,5 @@
-# Backend URL (optional, defaults to http://localhost:3008)
-NEXT_PUBLIC_BACKEND_URL=http://localhost:3008
+# Backend URL (optional). Leave unset to use same-origin relative requests,
+# which is correct when running the packaged single-binary server (frontend and
+# backend served from the same port). Only set this when the frontend is served
+# separately from the backend, e.g. `npm run dev` (frontend :3007 → backend :3008).
+# NEXT_PUBLIC_BACKEND_URL=http://localhost:3008

--- a/src/components/design-doc-viewer.tsx
+++ b/src/components/design-doc-viewer.tsx
@@ -21,7 +21,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import "highlight.js/styles/github-dark.css";
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
 export interface DesignDocViewerProps {
   /** Path to design doc (e.g., ".designs/{EPIC_ID}.md") */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,7 +5,11 @@
 
 import type { Project, Tag, Bead, WorktreeStatus, WorktreeEntry, PRStatus, PRFilesResponse, MemoryResponse, MemoryStats, MemoryEntry, Agent, AgentModel } from '@/types';
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
+// Default to same-origin (relative URLs) so the embedded frontend works from
+// any host the backend is reached on (localhost, a LAN IP, a Tailscale name),
+// not just localhost. Set NEXT_PUBLIC_BACKEND_URL to target a separate backend
+// (e.g. `npm run dev` frontend on :3007 → backend on :3008).
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
 /**
  * Input for creating a new project

--- a/src/lib/design-doc.ts
+++ b/src/lib/design-doc.ts
@@ -3,7 +3,7 @@
  * Shared functions for fetching and processing design documents
  */
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
 /**
  * Fetch design doc content from the backend API


### PR DESCRIPTION
Closes #95

## Problem

The packaged server embeds the frontend and serves it and the API from the same port, but the frontend hardcoded `http://localhost:3008` as its API base default. When the server is reached on any host other than localhost (LAN IP, Tailscale hostname, reverse-proxy domain), the browser tries to fetch from `localhost:3008` — the user's own machine — and every request fails with "Failed to fetch" / "Error loading projects", even though the backend is running.

## Fix

Default `API_BASE` to `''` (same-origin/relative), matching the single-binary deployment where frontend and backend share an origin. `NEXT_PUBLIC_BACKEND_URL` still overrides for split frontend/backend setups (`npm run dev` frontend :3007 → backend :3008). Relative URLs resolve against the page origin for both `fetch` and `EventSource`.

Changed in `src/lib/api.ts`, `src/lib/design-doc.ts`, `src/components/design-doc-viewer.tsx`; updated `.env.local.example`.

## Verification

Built the packaged binary and accessed it from a second machine over Tailscale (`http://<host>:3008`):

- **Before:** frontend renders but "Error loading projects: Failed to fetch"; DevTools shows failed requests to `http://localhost:3008/api/...`.
- **After:** built bundle contains zero `localhost:3008` references; `/api/projects` and `/api/beads` load correctly from the serving host.

No behavior change for the standard localhost workflow (relative requests resolve to localhost there too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)